### PR TITLE
Omnibus marmalade ns, sale into standard, fungible-v2 test coverage and other fixes

### DIFF
--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -40,7 +40,7 @@ jobs:
           distribution: "ubuntu-18.04"
       - name: pact/hft.repl
         run: |
-          bin/pact -t pact/hft.repl > out.log 2>&1
+          bin/pact -t pact/marmalade.repl > out.log 2>&1
           cat out.log
           r=`tail -1 out.log | grep "Load successful"`
           if [ -n "$r" ]; then exit 0; else echo "Pact run failed."; exit 1; fi

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -70,26 +70,26 @@
   )
 
 
-  (defun init-sale:bool
+  (defun enforce-offer:bool
     ( token:object{token-info}
       seller:string
       amount:decimal
-      sale:string
+      sale-id:string
     )
     @doc "Capture quote spec for SALE of TOKEN from message"
-    (enforce-sale-pact sale)
+    (enforce-sale-pact sale-id)
     (let ( (spec:object{quote-spec} (read-msg QUOTE) ) )
-      (insert quotes sale { 'id: (at 'id token), 'spec: spec }))
+      (insert quotes sale-id { 'id: (at 'id token), 'spec: spec }))
   )
 
-  (defun enforce-sale:bool
+  (defun enforce-buy:bool
     ( token:object{token-info}
       seller:string
       buyer:string
       amount:decimal
-      sale:string )
-    (enforce-sale-pact sale)
-    (with-read quotes sale { 'id:= qtoken, 'spec:= spec:object{quote-spec} }
+      sale-id:string )
+    (enforce-sale-pact sale-id)
+    (with-read quotes sale-id { 'id:= qtoken, 'spec:= spec:object{quote-spec} }
       (enforce (= qtoken (at 'id token)) "incorrect sale token")
       (bind spec
         { 'fungible := fungible:module{fungible-v2}

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -35,18 +35,6 @@
 
   (deftable quotes:{quote-schema})
 
-  (defun init-fqp
-    ( id:string
-      mint-guard:guard
-      max-supply:decimal
-      min-amount:decimal
-    )
-    (insert policies id
-      { 'mint-guard: mint-guard
-      , 'max-supply: max-supply
-      , 'min-amount: min-amount })
-  )
-
   (defun get-policy:object{policy-schema} (token:object{token-info})
     (read policies (at 'id token))
   )
@@ -75,8 +63,10 @@
   (defun enforce-init:bool
     ( token:object{token-info}
     )
-    (get-policy token)
-    true
+    (insert policies (at 'id token)
+      { 'mint-guard: (read-keyset 'mint-guard)
+      , 'max-supply: (read-decimal 'max-supply)
+      , 'min-amount: (read-decimal 'min-amount) })
   )
 
 

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -115,6 +115,15 @@
     (enforce false "Transfer prohibited")
   )
 
+  (defun enforce-crosschain:bool
+    ( token:object{token-info}
+      sender:string
+      receiver:string
+      target-chain:string
+      amount:decimal )
+    (enforce false "Transfer prohibited")
+  )
+
   ;; dummy impl to address #928
   (implements gas-payer-v1)
   (defcap GAS_PAYER:bool

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -67,6 +67,7 @@
       { 'mint-guard: (read-keyset 'mint-guard)
       , 'max-supply: (read-decimal 'max-supply)
       , 'min-amount: (read-decimal 'min-amount) })
+    true
   )
 
 

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -7,7 +7,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'hft-admin )))
 
-  (implements token-policy-v1_DRAFT1)
+  (implements kip.token-policy-v1_DRAFT1)
+  (use kip.token-policy-v1_DRAFT1 [token-info])
 
   (defschema policy-schema
     mint-guard:guard
@@ -46,12 +47,12 @@
       , 'min-amount: min-amount })
   )
 
-  (defun get-policy:object{policy-schema} (token:object{token-policy-v1_DRAFT1.token-info})
+  (defun get-policy:object{policy-schema} (token:object{token-info})
     (read policies (at 'id token))
   )
 
   (defun enforce-mint:bool
-    ( token:object{token-policy-v1_DRAFT1.token-info}
+    ( token:object{token-info}
       account:string
       amount:decimal
     )
@@ -64,7 +65,7 @@
   ))
 
   (defun enforce-burn:bool
-    ( token:object{token-policy-v1_DRAFT1.token-info}
+    ( token:object{token-info}
       account:string
       amount:decimal
     )
@@ -72,7 +73,7 @@
   )
 
   (defun enforce-init:bool
-    ( token:object{token-policy-v1_DRAFT1.token-info}
+    ( token:object{token-info}
     )
     (get-policy token)
     true
@@ -80,7 +81,7 @@
 
 
   (defun init-sale:bool
-    ( token:object{token-policy-v1_DRAFT1.token-info}
+    ( token:object{token-info}
       seller:string
       amount:decimal
       sale:string
@@ -92,7 +93,7 @@
   )
 
   (defun enforce-sale:bool
-    ( token:object{token-policy-v1_DRAFT1.token-info}
+    ( token:object{token-info}
       seller:string
       buyer:string
       amount:decimal
@@ -117,7 +118,7 @@
   )
 
   (defun enforce-transfer:bool
-    ( token:object{token-policy-v1_DRAFT1.token-info}
+    ( token:object{token-info}
       sender:string
       receiver:string
       amount:decimal )
@@ -130,7 +131,7 @@
     ( user:string limit:integer price:decimal )
     (enforce false "Dummy implementation"))
   (defun create-gas-payer-guard:guard ()
-    (enforce false "Dummy implementation"))  
+    (enforce false "Dummy implementation"))
 )
 
 

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -7,8 +7,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'hft-admin )))
 
-  (implements kip.token-policy-v1_DRAFT1)
-  (use kip.token-policy-v1_DRAFT1 [token-info])
+  (implements kip.token-policy-v1_DRAFT2)
+  (use kip.token-policy-v1_DRAFT2 [token-info])
 
   (defschema policy-schema
     mint-guard:guard

--- a/pact/kip/poly-fungible-v2.pact
+++ b/pact/kip/poly-fungible-v2.pact
@@ -173,5 +173,43 @@
       " Give manifest for ID."
   )
 
+  ;;
+  ;; Sale API
+  ;;
+
+  (defcap SALE:bool
+    (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Wrapper cap/event of SALE of token ID by SELLER of AMOUNT until TIMEOUT block height."
+    @event
+  )
+
+  (defcap OFFER:bool
+    (id:string seller:string amount:decimal timeout:integer)
+    @doc "Managed cap for SELLER offering AMOUNT of token ID until TIMEOUT."
+    @managed
+  )
+
+  (defcap WITHDRAW:bool
+    (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after TIMEOUT."
+    @event
+  )
+
+  (defcap BUY:bool
+    (id:string seller:string buyer:string amount:decimal timeout:integer sale-id:string)
+    @doc "Completes sale OFFER to BUYER."
+    @managed
+  )
+
+  (defpact sale:bool
+    ( id:string
+      seller:string
+      amount:decimal
+      timeout:integer
+    )
+    @doc " Offer->buy escrow pact of AMOUNT of token ID by SELLER with TIMEOUT in blocks. \
+         \ Step 1 is offer with withdraw rollback after timeout. \
+         \ Step 2 is buy, which completes using 'buyer' and 'buyer-guard' payload values."
+  )
 
 )

--- a/pact/kip/poly-fungible-v2.pact
+++ b/pact/kip/poly-fungible-v2.pact
@@ -2,7 +2,7 @@
 
 (namespace 'kip)
 
-(interface poly-fungible-v2_DRAFT1
+(interface poly-fungible-v2_DRAFT2
 
   (defschema account-details
     @doc

--- a/pact/kip/token-policy-v1.pact
+++ b/pact/kip/token-policy-v1.pact
@@ -1,0 +1,65 @@
+(namespace 'kip)
+
+(interface token-policy-v1_DRAFT1
+
+  (defschema token-info
+    id:string
+    supply:decimal
+    precision:integer
+    manifest:object{kip.token-manifest.manifest})
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    @doc "Minting policy for TOKEN"
+    @model [
+      (property (!= account ""))
+      (property (> amount 0.0))
+    ]
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    @doc "Burning policy for TOKEN"
+    @model [
+      (property (!= account ""))
+      (property (> amount 0.0))
+    ]
+  )
+
+  (defun enforce-init:bool
+    (token:object{token-info})
+    @doc "Enforce rules on TOKEN initiation."
+  )
+
+  (defun init-sale:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      sale:string )
+    @doc "Initialize SALE by SELLER of AMOUNT of TOKEN."
+  )
+
+
+  (defun enforce-sale:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      amount:decimal
+      sale:string )
+    @doc "Enforce rules on SALE by SELLER to BUYER AMOUNT of TOKEN."
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      receiver:string
+      amount:decimal )
+    @doc "Enforce rules on transfer of TOKEN AMOUNT from SENDER to RECEIVER."
+  )
+)

--- a/pact/kip/token-policy-v1.pact
+++ b/pact/kip/token-policy-v1.pact
@@ -1,6 +1,6 @@
 (namespace 'kip)
 
-(interface token-policy-v1_DRAFT1
+(interface token-policy-v1_DRAFT2
 
   (defschema token-info
     id:string

--- a/pact/kip/token-policy-v1.pact
+++ b/pact/kip/token-policy-v1.pact
@@ -13,7 +13,7 @@
       account:string
       amount:decimal
     )
-    @doc "Minting policy for TOKEN"
+    @doc "Minting policy for TOKEN to ACCOUNT for AMOUNT."
     @model [
       (property (!= account ""))
       (property (> amount 0.0))
@@ -25,7 +25,7 @@
       account:string
       amount:decimal
     )
-    @doc "Burning policy for TOKEN"
+    @doc "Burning policy for TOKEN to ACCOUNT for AMOUNT."
     @model [
       (property (!= account ""))
       (property (> amount 0.0))
@@ -34,25 +34,25 @@
 
   (defun enforce-init:bool
     (token:object{token-info})
-    @doc "Enforce rules on TOKEN initiation."
+    @doc "Enforce policy on TOKEN initiation."
   )
 
-  (defun init-sale:bool
+  (defun enforce-offer:bool
     ( token:object{token-info}
       seller:string
       amount:decimal
-      sale:string )
-    @doc "Initialize SALE by SELLER of AMOUNT of TOKEN."
+      sale-id:string )
+    @doc "Offer policy of sale SALE-ID by SELLER of AMOUNT of TOKEN."
   )
 
 
-  (defun enforce-sale:bool
+  (defun enforce-buy:bool
     ( token:object{token-info}
       seller:string
       buyer:string
       amount:decimal
-      sale:string )
-    @doc "Enforce rules on SALE by SELLER to BUYER AMOUNT of TOKEN."
+      sale-id:string )
+    @doc "Buy policy on SALE-ID by SELLER to BUYER AMOUNT of TOKEN."
   )
 
   (defun enforce-transfer:bool

--- a/pact/kip/token-policy-v1.pact
+++ b/pact/kip/token-policy-v1.pact
@@ -60,6 +60,17 @@
       sender:string
       receiver:string
       amount:decimal )
-    @doc "Enforce rules on transfer of TOKEN AMOUNT from SENDER to RECEIVER."
+    @doc " Enforce rules on transfer of TOKEN AMOUNT from SENDER to RECEIVER. \
+         \ Also governs rotate of SENDER (with same RECEIVER and 0.0 AMOUNT). "
+  )
+
+  (defun enforce-crosschain:bool
+    ( token:object{token-info}
+      sender:string
+      receiver:string
+      target-chain:string
+      amount:decimal )
+    @doc " Enforce rules on crosschain transfer of TOKEN AMOUNT \
+         \ from SENDER to RECEIVER on TARGET-CHAIN."
   )
 )

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -11,8 +11,8 @@
   (use util.fungible-util)
   (use kip.token-manifest)
 
-  (implements kip.poly-fungible-v2_DRAFT1)
-  (use kip.poly-fungible-v2_DRAFT1 [account-details])
+  (implements kip.poly-fungible-v2_DRAFT2)
+  (use kip.poly-fungible-v2_DRAFT2 [account-details])
 
   ;;
   ;; Tables/Schemas
@@ -25,7 +25,7 @@
     manifest:object{manifest}
     precision:integer
     supply:decimal
-    policy:module{kip.token-policy-v1_DRAFT1}
+    policy:module{kip.token-policy-v1_DRAFT2}
   )
 
   (deftable tokens:{token-schema})
@@ -111,13 +111,13 @@
   )
 
   (defschema policy-info
-    policy:module{kip.token-policy-v1_DRAFT1}
-    token:object{kip.token-policy-v1_DRAFT1.token-info}
+    policy:module{kip.token-policy-v1_DRAFT2}
+    token:object{kip.token-policy-v1_DRAFT2.token-info}
   )
 
   (defun get-policy-info:object{policy-info} (id:string)
     (with-read tokens id
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT1}
+      { 'policy := policy:module{kip.token-policy-v1_DRAFT2}
       , 'supply := supply
       , 'precision := precision
       , 'manifest := manifest
@@ -158,7 +158,7 @@
     ( id:string
       precision:integer
       manifest:object{manifest}
-      policy:module{kip.token-policy-v1_DRAFT1}
+      policy:module{kip.token-policy-v1_DRAFT2}
     )
     (enforce-verify-manifest manifest)
     (policy::enforce-init
@@ -221,7 +221,7 @@
       amount:decimal
     )
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT1}
+      { 'policy := policy:module{kip.token-policy-v1_DRAFT2}
       , 'token := token }
       (policy::enforce-transfer token sender receiver amount))
   )
@@ -251,7 +251,7 @@
     )
     (with-capability (MINT id account amount)
       (bind (get-policy-info id)
-        { 'policy := policy:module{kip.token-policy-v1_DRAFT1}
+        { 'policy := policy:module{kip.token-policy-v1_DRAFT2}
         , 'token := token }
         (policy::enforce-mint token account amount))
       (credit id account guard amount)
@@ -265,7 +265,7 @@
     )
     (with-capability (BURN id account amount)
       (bind (get-policy-info id)
-        { 'policy := policy:module{kip.token-policy-v1_DRAFT1}
+        { 'policy := policy:module{kip.token-policy-v1_DRAFT2}
         , 'token := token }
         (policy::enforce-burn token account amount))
       (debit id account amount)
@@ -466,7 +466,7 @@
     @doc "Initiate sale with by SELLER by escrowing AMOUNT of TOKEN until TIMEOUT."
     (require-capability (SALE_PRIVATE (pact-id)))
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT1}
+      { 'policy := policy:module{kip.token-policy-v1_DRAFT2}
       , 'token := token }
       (policy::enforce-offer token seller amount (pact-id)))
     (debit id seller amount)
@@ -498,7 +498,7 @@
     @doc "Complete sale with transfer."
     (require-capability (SALE_PRIVATE (pact-id)))
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT1}
+      { 'policy := policy:module{kip.token-policy-v1_DRAFT2}
       , 'token := token }
       (policy::enforce-buy token seller buyer amount sale-id))
     (debit id (sale-account) amount)

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -400,7 +400,7 @@
   ;; sale
   ;;
 
-  (defcap SALE
+  (defcap SALE:bool
     (id:string seller:string amount:decimal timeout:integer sale-id:string)
     @doc "Wrapper cap/event of SALE of token ID by SELLER of AMOUNT until TIMEOUT block height."
     @event
@@ -408,7 +408,7 @@
     (compose-capability (SALE_PRIVATE sale-id))
   )
 
-  (defcap OFFER
+  (defcap OFFER:bool
     (id:string seller:string amount:decimal timeout:integer)
     @doc "Managed cap for SELLER offering AMOUNT of token ID until TIMEOUT."
     @managed
@@ -417,7 +417,7 @@
     (compose-capability (CREDIT id (sale-account)))
   )
 
-  (defcap WITHDRAW
+  (defcap WITHDRAW:bool
     (id:string seller:string amount:decimal timeout:integer sale-id:string)
     @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after timeout."
     @event
@@ -427,7 +427,7 @@
     (compose-capability (SALE_PRIVATE sale-id))
   )
 
-  (defcap BUY
+  (defcap BUY:bool
     (id:string seller:string buyer:string amount:decimal timeout:integer sale-id:string)
     @doc "Completes sale OFFER to BUYER."
     @managed
@@ -439,7 +439,7 @@
 
   (defcap SALE_PRIVATE (sale-id:string) true)
 
-  (defpact sale
+  (defpact sale:bool
     ( id:string
       seller:string
       amount:decimal
@@ -468,7 +468,7 @@
     (bind (get-policy-info id)
       { 'policy := policy:module{kip.token-policy-v1_DRAFT1}
       , 'token := token }
-      (policy::init-sale token seller amount (pact-id)))
+      (policy::enforce-offer token seller amount (pact-id)))
     (debit id seller amount)
     (credit id (sale-account) (create-pact-guard "SALE") amount)
     (emit-event (TRANSFER id seller (sale-account) amount))
@@ -500,7 +500,7 @@
     (bind (get-policy-info id)
       { 'policy := policy:module{kip.token-policy-v1_DRAFT1}
       , 'token := token }
-      (policy::enforce-sale token seller buyer amount sale-id))
+      (policy::enforce-buy token seller buyer amount sale-id))
     (debit id (sale-account) amount)
     (credit id buyer buyer-guard amount)
     (emit-event (TRANSFER id (sale-account) buyer amount))

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -1,39 +1,65 @@
 (begin-tx)
-(define-namespace 'kip (sig-keyset) (sig-keyset))
+
 (load "root/fungible-v2.pact")
 (load "root/gas-payer-v1.pact")
 (load "root/coin.pact")
+
+(define-namespace 'kip (sig-keyset) (sig-keyset))
+
 (load "kip/account-protocols-v1.pact")
 (load "kip/manifest.pact")
 (load "kip/poly-fungible-v2.pact")
+(load "kip/token-policy-v1.pact")
 
 (define-namespace 'util (sig-keyset) (sig-keyset))
 (load "util/fungible-util.pact")
 
-(define-namespace 'hft (sig-keyset) (sig-keyset))
+(define-namespace 'marmalade (sig-keyset) (sig-keyset))
 (env-data
- { 'hft-admin: []
- , 'ns: "hft"
+ { 'marmalade-admin: []
+ , 'ns: "marmalade"
  , 'upgrade: false })
 (load "policy.pact")
 (commit-tx)
 
 (begin-tx)
-(load "hft.pact")
-(typecheck "hft.hft")
+(load "ledger.pact")
+(typecheck "marmalade.ledger")
 (commit-tx)
+
+;; fungible test
+(begin-tx)
+(load "test/ledger-test-fungible.pact")
+(load "test/fungible.repl")
+(use kip.token-manifest)
+(env-data {'mint-guard: []
+, 'burn-guard: []
+, 'sale-guard: []
+, 'transfer-guard: [] })
+(marmalade.ledger.create-token
+  TOKEN
+  12
+  (create-manifest (uri "text" "token") [])
+  marmalade.guard-token-policy)
+(test-capability (marmalade.ledger.CREDIT TOKEN FUNDER_ACCT))
+(expect "fund success" true
+  (test-fund FUNDER_ACCT FUNDER_GUARD FUNDER_BALANCE))
+(commit-tx)
+
+(fungible-v2-test.suite ledger-test-fungible
+   fungible-test-helper-default "rotate-tests transfer-crosschain-tests")
 
 (begin-tx)
 (env-data
  { 'bob-ks: ["bob"]
  , 'alice-ks: ["alice"]
- , 'mint-ks: ["mint"]
- , 'burn-ks: ["burn"]
- , 'sale-ks: ["sale"]
- , 'transfer-ks: ["transfer"]
+ , 'mint-guard: ["mint"]
+ , 'burn-guard: ["burn"]
+ , 'sale-guard: ["sale"]
+ , 'transfer-guard: ["transfer"]
  })
 (env-keys ["bob"])
-(use hft.hft)
+(use marmalade.ledger)
 
 (env-sigs [
   { 'key: "bob"
@@ -63,34 +89,8 @@
   { 'key: "transfer", 'caps: [] }
   ])
 
-(hft.guard-token-policy.init-guards
-  "project-0"
-  (read-keyset 'mint-ks )
-  (read-keyset 'burn-ks )
-  (read-keyset 'sale-ks)
-  (read-keyset 'transfer-ks))
-
 (use kip.token-manifest)
 
-(expect
-  "bob creates a new token project-0"
-  "Write succeeded"
-  (create-token
-    "project-0"
-    12
-    (create-manifest (uri "text" "project-0-uri") [])
-    hft.guard-token-policy)
-  )
-
-(expect-failure
-  "bob creates a new token project-1 before initialization"
-  "read: row not found: project-1"
-  (create-token
-    "project-1"
-    12
-    (create-manifest (uri "text" "project-0-uri") [])
-    hft.guard-token-policy)
-  )
 
 (expect-failure
   "bob creates a new token project-1 before initialization"
@@ -101,8 +101,19 @@
     {"uri": (uri "text" "project-0-uri"),
      "hash": "wrong-hash",
      "data": []}
-    hft.guard-token-policy)
+    marmalade.guard-token-policy)
   )
+
+(expect
+  "bob creates a new token project-0"
+  "Write succeeded"
+  (create-token
+    "project-0"
+    12
+    (create-manifest (uri "text" "project-0-uri") [])
+    marmalade.guard-token-policy)
+  )
+
 
 (expect
   "bob mints a 5.0 of token"
@@ -115,9 +126,9 @@
   (total-supply "project-0"))
 
 (expect "MINT events"
-   [{"name": "hft.hft.CREATE_TOKEN","params": ["project-0"]}
-   {"name": "hft.hft.MINT","params": ["project-0" "bob" 5.0]}
-   {"name": "hft.hft.SUPPLY","params": ["project-0" 5.0]} ]
+   [{"name": "marmalade.ledger.TOKEN","params": ["project-0"]}
+   {"name": "marmalade.ledger.MINT","params": ["project-0" "bob" 5.0]}
+   {"name": "marmalade.ledger.SUPPLY","params": ["project-0" 5.0]} ]
   (map (remove 'module-hash) (env-events true)))
 
 ;;regular transfer
@@ -126,14 +137,14 @@
   (transfer-create "project-0" "bob" "alice" (read-keyset 'alice-ks) 2.0))
 
 (expect "TRANSFER event"
-   [{"name": "hft.hft.TRANSFER","params": ["project-0" "bob" "alice" 2.0]}
+   [{"name": "marmalade.ledger.TRANSFER","params": ["project-0" "bob" "alice" 2.0]}
    ]
   (map (remove 'module-hash) (env-events true)))
 
 (commit-tx)
 
 (begin-tx)
-(use hft.hft)
+(use marmalade.ledger)
 
 (env-sigs [
   {
@@ -176,13 +187,13 @@
 (env-sigs
   [{'key:'bob
    ,'caps:
-    [(hft.hft.TRANSFER 'project-0 'bob
+    [(marmalade.ledger.TRANSFER 'project-0 'bob
       "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f3"
       0.04),
-    (hft.hft.TRANSFER 'project-0 'bob
+    (marmalade.ledger.TRANSFER 'project-0 'bob
       "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4"
       0.02),
-    (hft.hft.TRANSFER 'project-0 'bob
+    (marmalade.ledger.TRANSFER 'project-0 'bob
       "c:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4"
       0.04)
       ]}
@@ -193,14 +204,14 @@
 (expect-failure
   "single-key mismatch, create-account"
   "Single-key account protocol violation"
-  (hft.hft.create-account 'project-0
+  (marmalade.ledger.create-account 'project-0
     "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f3"
     (read-keyset 'k)))
 
 (expect-failure
   "single-key mismatch, transfer-create"
   "Single-key account protocol violation"
-  (hft.hft.transfer-create
+  (marmalade.ledger.transfer-create
     'project-0
     'bob
     "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f3"
@@ -210,7 +221,7 @@
 (expect-failure
   "single-key mismatch, transfer-create"
   "Single-key account protocol violation"
-  (hft.hft.transfer-create
+  (marmalade.ledger.transfer-create
     'project-0
     'bob
     "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f3"
@@ -220,7 +231,7 @@
 (expect-failure
   "multi-key, transfer-create"
   "Single-key account protocol violation"
-  (hft.hft.transfer-create
+  (marmalade.ledger.transfer-create
     'project-0
     'bob
     "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f3"
@@ -230,7 +241,7 @@
 (expect-failure
   "bad protocol, transfer-create"
   "Unrecognized reserved protocol: c"
-  (hft.hft.transfer-create
+  (marmalade.ledger.transfer-create
     'project-0
     'bob
     "c:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4"
@@ -240,14 +251,14 @@
 (expect-failure
   "bad protocol, create-account"
   "Unrecognized reserved protocol: c"
-  (hft.hft.create-account 'project-0
+  (marmalade.ledger.create-account 'project-0
     "c:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4"
     (read-keyset 'k2)))
 
 (expect-failure
   "single-key mismatch, create-account"
   "Single-key account protocol violation"
-  (hft.hft.create-account
+  (marmalade.ledger.create-account
     'project-0
     "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f3"
     (read-keyset 'k)))
@@ -255,7 +266,7 @@
 (expect
   "single-key success, create-account"
   "Write succeeded"
-  (hft.hft.create-account 'project-0
+  (marmalade.ledger.create-account 'project-0
     "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4"
     (read-keyset 'k)))
 
@@ -265,8 +276,8 @@
   ,"balance": 0.0
   ,"guard": (read-keyset 'k)
   ,"id": "project-0"}
-  (hft.hft.get-ledger-entry
-    (hft.hft.key 'project-0 "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4")))
+  (marmalade.ledger.get-ledger-entry
+    (marmalade.ledger.key 'project-0 "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4")))
 
 (rollback-tx)
 
@@ -277,7 +288,7 @@
 (env-sigs
   [{'key:'bob
    ,'caps:
-    [(hft.hft.TRANSFER 'project-0 'bob
+    [(marmalade.ledger.TRANSFER 'project-0 'bob
       "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4"
       0.02)]}
   ,{'key:'transfer,'caps: []}
@@ -286,7 +297,7 @@
 (expect
   "single-key success, transfer-create"
   "Write succeeded"
-  (hft.hft.transfer-create
+  (marmalade.ledger.transfer-create
     'project-0
     'bob
     "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4"
@@ -299,13 +310,13 @@
   ,"balance": 0.02
   ,"guard": (read-keyset 'k)
   ,"id": "project-0"}
-  (hft.hft.get-ledger-entry
-    (hft.hft.key 'project-0 "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4")))
+  (marmalade.ledger.get-ledger-entry
+    (marmalade.ledger.key 'project-0 "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4")))
 
 
 (expect "TRANSFER events"
   [{
-  "name": "hft.hft.TRANSFER",
+  "name": "marmalade.ledger.TRANSFER",
   "params": ["project-0", "bob", "k:5b4c9fc5207fcf700a5fbcb48c261820149c8ecd52e005282ed9e3f5febcd1f4", 0.02]
   }]
   (map (remove 'module-hash) (env-events true)))
@@ -316,7 +327,7 @@
 
 ;; Test ACCESSORS
 
-(use hft.hft)
+(use marmalade.ledger)
 (use kip.token-manifest)
 
 (env-data
@@ -333,22 +344,17 @@
   (get-manifest 'project-0))
 
 (expect "Returns tokens"
-   [{"id": "project-0"
-    ,"manifest": {"data": []
-    ,"hash": "E0pcFalaFSk5AJwR7QwpLbhzymaC8DCOSrCeBiDkpnY"
-    ,"uri": {"data": "project-0-uri","scheme": "text"}}
-    ,"policy": hft.guard-token-policy,"precision": 12
-    ,"supply": 5.0}]
-  (get-tokens))
+  ["project-0","token"]
+  (map (at 'id) (get-tokens)))
 
 (expect "Returns token keys"
-   ["project-0"]
+   ["project-0","token"]
   (get-token-keys))
 
 (expect "Returns project-0 token"
   { 'id: "project-0"
   , 'manifest: (create-manifest (uri "text" "project-0-uri") [])
-  , 'policy: hft.guard-token-policy
+  , 'policy: marmalade.guard-token-policy
   , 'precision: 12
   , 'supply: 5.0
   }
@@ -356,7 +362,9 @@
 
 (expect "Returns ledger keys"
   [ "project-0:alice"
-    "project-0:bob" ]
+    "project-0:bob"
+    "token:FUNDER_ACCT"
+  ]
   (get-ledger-keys))
 
 (expect "get ledger entry"
@@ -368,35 +376,25 @@
   (get-ledger-entry (key 'project-0 'bob)))
 
 (expect "get ledger"
- [
-  { 'account: "alice"
-  , 'balance: 2.0
-  , 'guard: (read-keyset 'alice-ks)
-  , 'id: "project-0"
-  }
-  { 'account: "bob"
-  , 'balance: 3.0
-  , 'guard: (read-keyset 'bob-ks)
-  , 'id: "project-0"
-  }]
- (get-ledger))
+ [ "alice" "bob" "FUNDER_ACCT" ]
+ (map (at 'account) (get-ledger)))
 
 (rollback-tx)
 
 ;;sales policy
 (begin-tx "sale guard policy success")
 (env-hash (hash "sale-tx1"))
-(use hft.hft)
+(use marmalade.ledger)
 (env-chain-data {"block-height": 100})
 (env-sigs
   [{'key:'bob
    ,'caps:
-    [(hft.hft.OFFER "project-0" "bob" 0.1 110)
-     (hft.hft.OFFER "project-0" "bob" 0.1 10)
+    [(marmalade.ledger.OFFER "project-0" "bob" 0.1 110)
+     (marmalade.ledger.OFFER "project-0" "bob" 0.1 10)
      ]}
   ,{'key:'sale,'caps: [
-    (hft.hft.OFFER "project-0" "bob" 0.1 10)
-    (hft.hft.BUY "project-0" "bob" "buyer" 0.1 110 (hash "sale-tx1"))
+    (marmalade.ledger.OFFER "project-0" "bob" 0.1 10)
+    (marmalade.ledger.BUY "project-0" "bob" "buyer" 0.1 110 (hash "sale-tx1"))
     ]}
   ])
 
@@ -415,7 +413,7 @@
 
 (env-sigs
   [{'key:'sale,'caps: [
-    (hft.hft.OFFER "project-0" "bob" 0.1 110)
+    (marmalade.ledger.OFFER "project-0" "bob" 0.1 110)
     ]}
   ])
 
@@ -425,10 +423,10 @@
 
 (env-sigs
   [{'key:'bob,'caps: [
-    (hft.hft.OFFER "project-0" "bob" 0.1 110)
+    (marmalade.ledger.OFFER "project-0" "bob" 0.1 110)
     ]}
   ,{'key:'sale,'caps: [
-     (hft.hft.OFFER "project-0" "bob" 0.1 110)
+     (marmalade.ledger.OFFER "project-0" "bob" 0.1 110)
    ]}
   ])
 
@@ -441,14 +439,14 @@
   (map (get-balance 'project-0) ['bob (sale-account)]))
 
 (expect "OFFER events"
-  [{"name": "hft.hft.OFFER","params": ["project-0" "bob" 0.1 110]}
-   {"name": "hft.hft.SALE","params": ["project-0" "bob" 0.1 110 (hash "sale-tx1")]}
-   {"name": "hft.hft.TRANSFER","params": ["project-0" "bob" (sale-account) 0.1]}]
+  [{"name": "marmalade.ledger.OFFER","params": ["project-0" "bob" 0.1 110]}
+   {"name": "marmalade.ledger.SALE","params": ["project-0" "bob" 0.1 110 (hash "sale-tx1")]}
+   {"name": "marmalade.ledger.TRANSFER","params": ["project-0" "bob" (sale-account) 0.1]}]
   (map (remove 'module-hash) (env-events true)))
 
 (env-sigs
   [{'key:'dummy,'caps: [
-     (hft.hft.BUY "project-0" "bob" "buyer" 0.1 110 (pact-id))
+     (marmalade.ledger.BUY "project-0" "bob" "buyer" 0.1 110 (pact-id))
    ]}])
 
 (expect-failure "Buy fails, sale guard not signed"
@@ -457,7 +455,7 @@
 
 (env-sigs
  [{'key:'sale,'caps: [
-    (hft.hft.BUY "project-0" "bob" "buyer" 0.1 110 (pact-id))
+    (marmalade.ledger.BUY "project-0" "bob" "buyer" 0.1 110 (pact-id))
   ]}])
 
 (expect "Buy succeeds"
@@ -469,8 +467,8 @@
   (map (get-balance 'project-0) [(sale-account) "buyer"]))
 
 (expect "BUY events"
-  [{"name": "hft.hft.BUY","params": ["project-0" "bob" "buyer" 0.1 110 (hash "sale-tx1")]}
-   {"name": "hft.hft.TRANSFER","params": ["project-0" (sale-account) "buyer" 0.1]}]
+  [{"name": "marmalade.ledger.BUY","params": ["project-0" "bob" "buyer" 0.1 110 (hash "sale-tx1")]}
+   {"name": "marmalade.ledger.TRANSFER","params": ["project-0" (sale-account) "buyer" 0.1]}]
   (map (remove 'module-hash) (env-events true)))
 
 (rollback-tx)
@@ -479,15 +477,15 @@
 
 (env-hash (hash "sale-tx2"))
 (env-chain-data {"block-height": 100})
-(use hft.hft)
+(use marmalade.ledger)
 (env-sigs
   [{'key:'bob
    ,'caps:
-    [(hft.hft.OFFER "project-0" "bob" 0.1 110)
+    [(marmalade.ledger.OFFER "project-0" "bob" 0.1 110)
      ]}
   ,{'key:'sale,'caps: [
-    (hft.hft.OFFER "project-0" "bob" 0.1 110)
-    (hft.hft.BUY "project-0" "bob" "buyer" 0.1 110 (hash "sale-tx2"))
+    (marmalade.ledger.OFFER "project-0" "bob" 0.1 110)
+    (marmalade.ledger.BUY "project-0" "bob" "buyer" 0.1 110 (hash "sale-tx2"))
     ]}
   ])
 
@@ -505,9 +503,9 @@
   (map (get-balance 'project-0) ['bob (sale-account)]))
 
 (expect "OFFER events"
-  [{"name": "hft.hft.OFFER","params": ["project-0" "bob" 0.1 110]}
-  {"name": "hft.hft.SALE","params": ["project-0" "bob" 0.1 110 (hash "sale-tx2")]}
-  {"name": "hft.hft.TRANSFER","params": ["project-0" "bob" (sale-account) 0.1]}]
+  [{"name": "marmalade.ledger.OFFER","params": ["project-0" "bob" 0.1 110]}
+  {"name": "marmalade.ledger.SALE","params": ["project-0" "bob" 0.1 110 (hash "sale-tx2")]}
+  {"name": "marmalade.ledger.TRANSFER","params": ["project-0" "bob" (sale-account) 0.1]}]
   (map (remove 'module-hash) (env-events true)))
 
 (env-chain-data {"block-height": 111})
@@ -525,8 +523,8 @@
   (map (get-balance 'project-0) ['bob (sale-account)]))
 
 (expect "WITHDRAW events"
-  [{"name": "hft.hft.WITHDRAW","params": ["project-0" "bob" 0.1 110 (hash "sale-tx2")]}
-   {"name": "hft.hft.TRANSFER","params": ["project-0" (sale-account) "bob" 0.1]}]
+  [{"name": "marmalade.ledger.WITHDRAW","params": ["project-0" "bob" 0.1 110 (hash "sale-tx2")]}
+   {"name": "marmalade.ledger.TRANSFER","params": ["project-0" (sale-account) "bob" 0.1]}]
   (map (remove 'module-hash) (env-events true)))
 
 (rollback-tx)
@@ -535,19 +533,19 @@
 (env-hash (hash "fixed-quote-sale-tx2"))
 (env-data {
    'upgrade: false
-  ,'ns: "hft"
+  ,'ns: "marmalade"
   ,'mint-guard: {"keys": ["mint"], "pred": "keys-all"}
   ,'bob-guard: {"keys": ["bob"], "pred": "keys-all"}
   })
 (env-sigs
   [{'key:'dummy
    ,'caps:
-    [(hft.hft.MINT "project-2" "bob" 1.0)
+    [(marmalade.ledger.MINT "project-2" "bob" 1.0)
      ]}])
 
 (load "fixed-quote-policy.pact")
 (use kip.token-manifest)
-(use hft.hft)
+(use marmalade.ledger)
 
 (expect "initiates project-2 with fixed quote policy"
   "Write succeeded"
@@ -556,7 +554,7 @@
 (expect "Create token project-2"
   "Write succeeded"
   (create-token "project-2" 1
-    (create-manifest (uri "text" "project-2-uri") []) hft.fixed-quote-policy))
+    (create-manifest (uri "text" "project-2-uri") []) marmalade.fixed-quote-policy))
 
 (expect-failure "bob mints project-2"
   "Failed: Keyset failure (keys-all): [mint]"
@@ -565,7 +563,7 @@
 (env-sigs
   [{'key:'mint
    ,'caps:
-    [(hft.hft.MINT "project-2" "bob" 1.0)
+    [(marmalade.ledger.MINT "project-2" "bob" 1.0)
      ]}])
 
 (expect "bob mints project-2"
@@ -577,20 +575,20 @@
   (get-balance 'project-2 'bob))
 
 (expect "Create and mint fqp token EVENTS"
-  [ {"name": "hft.hft.CREATE_TOKEN","params": ["project-2"]}
-    {"name": "hft.hft.MINT","params": ["project-2" "bob" 1.0]}
-    {"name": "hft.hft.SUPPLY","params": ["project-2" 1.0]}]
+  [ {"name": "marmalade.ledger.TOKEN","params": ["project-2"]}
+    {"name": "marmalade.ledger.MINT","params": ["project-2" "bob" 1.0]}
+    {"name": "marmalade.ledger.SUPPLY","params": ["project-2" 1.0]}]
     (map (remove 'module-hash) (env-events true)))
 
 (commit-tx)
 
 (begin-tx "sale fixed-quote-policy success")
 (env-hash (hash "fixed-quote-sale-tx2"))
-(use hft.hft)
+(use marmalade.ledger)
 (env-sigs
   [{'key:'bob
    ,'caps:
-    [(hft.hft.OFFER "project-2" "bob" 0.2 120)]}
+    [(marmalade.ledger.OFFER "project-2" "bob" 0.2 120)]}
  ])
 
 (env-data
@@ -628,9 +626,9 @@
   (map (get-balance 'project-2) ['bob (sale-account)]))
 
 (expect "OFFER events"
-   [{"name": "hft.hft.OFFER","params": ["project-2" "bob" 0.2 120]}
-    {"name": "hft.hft.SALE","params": ["project-2" "bob" 0.2 120 (pact-id)]}
-    {"name": "hft.hft.TRANSFER","params": ["project-2" "bob" (sale-account) 0.2]}]
+   [{"name": "marmalade.ledger.OFFER","params": ["project-2" "bob" 0.2 120]}
+    {"name": "marmalade.ledger.SALE","params": ["project-2" "bob" 0.2 120 (pact-id)]}
+    {"name": "marmalade.ledger.TRANSFER","params": ["project-2" "bob" (sale-account) 0.2]}]
   (map (remove 'module-hash) (env-events true)))
 
 
@@ -640,7 +638,7 @@
 
 (env-sigs [
   {'key: 'bob
-   ,'caps: [(hft.hft.BUY "project-2" "bob" "coin-buyer" 0.2 120 (hash "fixed-quote-sale-tx2"))]
+   ,'caps: [(marmalade.ledger.BUY "project-2" "bob" "coin-buyer" 0.2 120 (hash "fixed-quote-sale-tx2"))]
   }
 ,{'key: 'dummy
  ,'caps: [
@@ -653,7 +651,7 @@
 
 (env-sigs [
   {'key: 'bob
-   ,'caps: [(hft.hft.BUY "project-2" "bob" "coin-buyer" 0.2 120 (hash "fixed-quote-sale-tx2"))]
+   ,'caps: [(marmalade.ledger.BUY "project-2" "bob" "coin-buyer" 0.2 120 (hash "fixed-quote-sale-tx2"))]
   }
  ,{'key: 'buyer
  ,'caps: [
@@ -677,9 +675,9 @@
   (continue-pact 0 true))
 
 (expect "BUY events"
-   [{"name": "hft.hft.BUY","params": ["project-2" "bob" "coin-buyer" 0.2 120 (pact-id)]}
+   [{"name": "marmalade.ledger.BUY","params": ["project-2" "bob" "coin-buyer" 0.2 120 (pact-id)]}
     {"name": "coin.TRANSFER","params": ["coin-buyer" "alice" 0.2]}
-    {"name": "hft.hft.TRANSFER","params": ["project-2" (sale-account) "coin-buyer" 0.2]}]
+    {"name": "marmalade.ledger.TRANSFER","params": ["project-2" (sale-account) "coin-buyer" 0.2]}]
   (map (remove 'module-hash) (env-events true)))
 
 (rollback-tx)
@@ -687,12 +685,12 @@
 (begin-tx "sale fixed-quote-policy timeout/withdraw")
 (begin-tx "sale fixed-quote-policy success")
 (env-hash (hash "fixed-quote-sale-tx3"))
-(use hft.hft)
+(use marmalade.ledger)
 (env-sigs
   [{'key:'bob
    ,'caps:
-    [(hft.hft.OFFER "project-2" "bob" 0.2 120)
-     (hft.hft.BUY "project-2" "bob" "coin-buyer" 0.2 120 (hash "fixed-quote-sale-tx3"))
+    [(marmalade.ledger.OFFER "project-2" "bob" 0.2 120)
+     (marmalade.ledger.BUY "project-2" "bob" "coin-buyer" 0.2 120 (hash "fixed-quote-sale-tx3"))
      ]}
    {'key: 'buyer
    ,'caps: [
@@ -735,9 +733,9 @@
   (map (get-balance 'project-2) ['bob (sale-account)]))
 
 (expect "OFFER events"
-   [{"name": "hft.hft.OFFER","params": ["project-2" "bob" 0.2 120]}
-    {"name": "hft.hft.SALE","params": ["project-2" "bob" 0.2 120 (pact-id)]}
-    {"name": "hft.hft.TRANSFER","params": ["project-2" "bob" (sale-account) 0.2]}]
+   [{"name": "marmalade.ledger.OFFER","params": ["project-2" "bob" 0.2 120]}
+    {"name": "marmalade.ledger.SALE","params": ["project-2" "bob" 0.2 120 (pact-id)]}
+    {"name": "marmalade.ledger.TRANSFER","params": ["project-2" "bob" (sale-account) 0.2]}]
   (map (remove 'module-hash) (env-events true)))
 
 (env-chain-data {"block-height": 121})
@@ -763,8 +761,8 @@
   (continue-pact 0 true))
 
 (expect "WITHDRAW events"
-    [{"name": "hft.hft.WITHDRAW","params": ["project-2" "bob" 0.2 120 (pact-id)]}
-    {"name": "hft.hft.TRANSFER","params": ["project-2" (sale-account) "bob" 0.2]}]
+    [{"name": "marmalade.ledger.WITHDRAW","params": ["project-2" "bob" 0.2 120 (pact-id)]}
+    {"name": "marmalade.ledger.TRANSFER","params": ["project-2" (sale-account) "bob" 0.2]}]
   (map (remove 'module-hash) (env-events true)))
 
 (rollback-tx)

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -536,6 +536,8 @@
   ,'ns: "marmalade"
   ,'mint-guard: {"keys": ["mint"], "pred": "keys-all"}
   ,'bob-guard: {"keys": ["bob"], "pred": "keys-all"}
+  ,'max-supply: 10.0
+  ,'min-amount: 1.0
   })
 (env-sigs
   [{'key:'dummy
@@ -546,10 +548,6 @@
 (load "fixed-quote-policy.pact")
 (use kip.token-manifest)
 (use marmalade.ledger)
-
-(expect "initiates project-2 with fixed quote policy"
-  "Write succeeded"
-  (init-fqp "project-2" (read-keyset 'mint-guard) 10.0 1.0))
 
 (expect "Create token project-2"
   "Write succeeded"

--- a/pact/ns-hft.pact
+++ b/pact/ns-hft.pact
@@ -1,8 +1,0 @@
-(define-keyset 'hft-ns-user)
-(define-keyset 'hft-ns-admin)
-(ns.write-registry (read-msg 'ns) (keyset-ref-guard 'hft-ns-admin) true)
-(define-namespace
-  (read-msg 'ns)
-  (keyset-ref-guard 'hft-ns-user )
-  (keyset-ref-guard 'hft-ns-admin )
-)

--- a/pact/ns-marmalade.pact
+++ b/pact/ns-marmalade.pact
@@ -1,0 +1,8 @@
+(define-keyset 'marmalade-ns-user)
+(define-keyset 'marmalade-ns-admin)
+(ns.write-registry (read-msg 'ns) (keyset-ref-guard 'marmalade-ns-admin) true)
+(define-namespace
+  (read-msg 'ns)
+  (keyset-ref-guard 'marmalade-ns-user )
+  (keyset-ref-guard 'marmalade-ns-admin )
+)

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -1,76 +1,13 @@
 
 (namespace (read-msg 'ns))
 
-(interface token-policy-v1_DRAFT1
-
-  (defschema token-info
-    id:string
-    supply:decimal
-    precision:integer
-    manifest:object{kip.token-manifest.manifest})
-
-  (defun enforce-mint:bool
-    ( token:object{token-info}
-      account:string
-      amount:decimal
-    )
-    @doc "Minting policy for TOKEN"
-    @model [
-      (property (!= account ""))
-      (property (> amount 0.0))
-    ]
-  )
-
-  (defun enforce-burn:bool
-    ( token:object{token-info}
-      account:string
-      amount:decimal
-    )
-    @doc "Burning policy for TOKEN"
-    @model [
-      (property (!= account ""))
-      (property (> amount 0.0))
-    ]
-  )
-
-  (defun enforce-init:bool
-    (token:object{token-info})
-    @doc "Enforce that TOKEN policy is initialized"
-    )
-
-  (defun init-sale:bool
-    ( token:object{token-info}
-      seller:string
-      amount:decimal
-      sale:string )
-    @doc "Initialize SALE by SELLER of AMOUNT of TOKEN."
-  )
-
-
-  (defun enforce-sale:bool
-    ( token:object{token-info}
-      seller:string
-      buyer:string
-      amount:decimal
-      sale:string )
-    @doc "Enforce rules on SALE by SELLER to BUYER AMOUNT of TOKEN."
-  )
-
-  (defun enforce-transfer:bool
-    ( token:object{token-info}
-      sender:string
-      receiver:string
-      amount:decimal )
-    @doc "Enforce rules on transfer of TOKEN AMOUNT from SENDER to RECEIVER."
-  )
-)
-
 (module guard-token-policy GOVERNANCE
 
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'hft-admin )))
 
-  (implements token-policy-v1_DRAFT1)
+  (implements kip.token-policy-v1_DRAFT1)
+  (use kip.token-policy-v1_DRAFT1 [token-info])
 
   (defschema guards
     mint-guard:guard
@@ -80,18 +17,6 @@
   )
 
   (deftable policy-guards:{guards})
-
-  (defun init-guards
-    ( token:string
-      mint-guard:guard
-      burn-guard:guard
-      sale-guard:guard
-      transfer-guard:guard
-    )
-    (insert policy-guards token
-      { 'mint-guard: mint-guard, 'burn-guard: burn-guard
-      , 'sale-guard: sale-guard, 'transfer-guard: transfer-guard })
-  )
 
   (defun get-guards:object{guards} (token:object{token-info})
     (read policy-guards (at 'id token))
@@ -116,7 +41,11 @@
   (defun enforce-init:bool
     ( token:object{token-info}
     )
-    (get-guards token)
+    (insert policy-guards (at 'id token)
+      { 'mint-guard: (read-keyset 'mint-guard)
+      , 'burn-guard: (read-keyset 'burn-guard)
+      , 'sale-guard: (read-keyset 'sale-guard)
+      , 'transfer-guard: (read-keyset 'transfer-guard) })
     true
   )
 
@@ -154,7 +83,7 @@
     (enforce false "Dummy implementation"))
   (defun create-gas-payer-guard:guard ()
     (enforce false "Dummy implementation"))
-      
+
 )
 
 (create-table policy-guards)

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -50,20 +50,20 @@
   )
 
 
-  (defun init-sale:bool
+  (defun enforce-offer:bool
     ( token:object{token-info}
       seller:string
       amount:decimal
-      sale:string )
+      sale-id:string )
     (enforce-guard (at 'sale-guard (get-guards token)))
   )
 
-  (defun enforce-sale:bool
+  (defun enforce-buy:bool
     ( token:object{token-info}
       seller:string
       buyer:string
       amount:decimal
-      sale:string )
+      sale-id:string )
     (enforce-guard (at 'sale-guard (get-guards token)))
   )
 

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -76,6 +76,15 @@
     (enforce-guard (at 'transfer-guard (get-guards token)))
   )
 
+  (defun enforce-crosschain:bool
+    ( token:object{token-info}
+      sender:string
+      receiver:string
+      target-chain:string
+      amount:decimal )
+    (enforce-guard (at 'transfer-guard (get-guards token)))
+  )
+
   ;; dummy impl to address #928
   (implements gas-payer-v1)
   (defcap GAS_PAYER:bool

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -6,8 +6,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'hft-admin )))
 
-  (implements kip.token-policy-v1_DRAFT1)
-  (use kip.token-policy-v1_DRAFT1 [token-info])
+  (implements kip.token-policy-v1_DRAFT2)
+  (use kip.token-policy-v1_DRAFT2 [token-info])
 
   (defschema guards
     mint-guard:guard

--- a/pact/test/fungible.repl
+++ b/pact/test/fungible.repl
@@ -1,0 +1,787 @@
+
+
+(env-enable-repl-natives true)
+(env-data
+  { "alice": ["alice-key"]
+  , "bob": ["bob-key"]}
+  )
+
+(interface fungible-test-helper
+  "Interface for interacting with test."
+  (defun setup-rotate:bool
+    ( account:string
+      old-key:string
+    )
+    " Supply setup for 'rotate'. Simply return 'false' to use \
+    \ non-managed key-based setup, or perform managed capability \
+    \ setup with OLD_KEY and return 'true'."
+  )
+)
+
+(module fungible-test-helper-default G
+  (defcap G () true)
+  (implements fungible-test-helper)
+  (defun setup-rotate:bool (account:string old-key:string) false)
+)
+
+(module fungible-v2-test G
+  " Test suite for fungibles. "
+  (defcap G () true)
+
+  (defconst FUNDER_ACCT "FUNDER_ACCT"
+    "Name of test funding account")
+
+  (defconst FUNDER_GUARD:guard (funder-guard)
+    "Guard for test funding account")
+
+  (defconst FUNDER_BALANCE 10000.0
+    "Initial balance for test funding account")
+
+  (defcap XCHAIN ()
+    " Dummy capability for bringing sigs into scope \
+    \ for transfer-crosschain."
+    true
+  )
+
+  (defcap ROTATE ()
+    " Dummy capability for bringing sigs into scope \
+    \ for rotate."
+    true
+  )
+
+  (defconst ALICE "alice")
+  (defconst ALICE_KEY:string (at 0 (read-msg ALICE)))
+  (defconst ALICE_GUARD (read-keyset ALICE))
+
+  (defconst BOB "bob")
+  (defconst BOB_KEY (at 0 (read-msg BOB)))
+  (defconst BOB_GUARD (read-keyset BOB))
+
+  (defconst XCHAIN_HASH (hash "XCHAIN"))
+  (defconst CHAIN_0 "0")
+  (defconst CHAIN_1 "1")
+
+  (defun funder-guard ()
+    (create-module-guard "FUNDER_ACCT"))
+
+  (defun fund-create
+    ( f:module{fungible-v2}
+      account:string
+      guard:guard
+      amount:decimal )
+    "Fixture: create and fund ACCOUNT with GUARD for AMOUNT"
+    (install-capability (f::TRANSFER FUNDER_ACCT account amount))
+    (f::transfer-create FUNDER_ACCT account guard amount)
+  )
+
+  (defun fund
+    ( f:module{fungible-v2}
+      account:string
+      amount:decimal )
+    "Fixture: Fund existing ACCOUNT for AMOUNT"
+    (install-capability (f::TRANSFER FUNDER_ACCT account amount))
+    (f::transfer FUNDER_ACCT account amount)
+  )
+
+  (defun pow (v:decimal e:integer)
+    "Support negative exponents"
+    (if (>= e 0) (^ v e)
+      (fold (/) 1.0 (make-list (- e) v))))
+
+
+  (defun precision-min-value (f:module{fungible-v2})
+    "Compute minimum value for F fungible."
+    (pow 10.0 (- (f::precision))))
+
+
+  (defun begin-xchain
+    ( f:module{fungible-v2}
+      i:integer
+      account:string
+      guard:guard
+      key:string
+      fund-amount:decimal
+    )
+    " Fixture: set up transaction I for cross-chain, \
+    \ funding ACCOUNT/GUARD for FUND-AMOUNT \
+    \ and signing with KEY, setting hash to XCHAIN_HASH \
+    \ and sending chain to CHAIN_0."
+    (begin-tx (format "xchain-{}" [i]))
+    (fund-create f account guard fund-amount)
+    (env-hash XCHAIN_HASH)
+    (env-chain-data { 'chain-id: CHAIN_0 })
+    (env-sigs [{"key": key,"caps":[(XCHAIN)]}])
+  )
+
+
+  ;;
+  ;; TEST SUITE
+  ;;
+
+  (defun suite
+    ( f:module{fungible-v2}
+      h:module{fungible-test-helper}
+      skip:string
+    )
+    " Run suite on fungible module F. Requires special account \
+    \ 'FUNDER_ACCT' to exist with 'FUNDER_GUARD' guard and \
+    \ 'FUNDER_BALANCE' balance."
+    (fixture-tests f)
+    (or (contains "create-account-tests" skip)
+      (create-account-tests f))
+    (or (contains "transfer-tests" skip)
+      (transfer-tests f))
+    (or (contains "transfer-create-tests" skip)
+      (transfer-create-tests f))
+    (or (contains "transfer-crosschain-tests" skip)
+      (transfer-crosschain-tests f))
+    (or (contains "rotate-tests" skip)
+      (rotate-tests f h))
+    (or (contains "enforce-unit-tests" skip)
+      (enforce-unit-tests f))
+  )
+
+  (defun fixture-tests:bool (f:module{fungible-v2})
+    (expect "Funder account funded" 10000.0
+      (f::get-balance FUNDER_ACCT))
+    (expect "pow 10 -1" 0.1 (pow 10.0 -1))
+    (expect "pow 10 -2" 0.01 (pow 10.0 -2))
+    (expect "pow 4 -3" 0.015625 (pow 4.0 -3))
+    (expect "pow 9 3" 729.0 (pow 9.0 3))
+  )
+
+  (defun create-account-tests:bool (f:module{fungible-v2})
+    " Covers:                                  \
+    \ 1) inherent create-account invariants.   "
+
+    (begin-tx "create-account-tests")
+
+    (expect-failure
+      "Uncreated account does not exist"
+      (f::details BOB))
+
+    (expect-failure
+      "Account creation with empty ID fails [implied by transfer properties]"
+      (f::create-account "" BOB_GUARD))
+
+    (expect-that "Account creation succeeds"
+      (constantly true) ;; avoid requiring specific response
+      (f::create-account BOB BOB_GUARD))
+
+    (expect
+      "Account successfully created with correct details"
+      { 'account: BOB
+      , 'balance: 0.0
+      , 'guard: BOB_GUARD
+      }
+      (f::details BOB))
+
+    (expect
+      "Account balance correct"
+      0.0
+      (f::get-balance BOB))
+
+    (expect-failure
+      "Creation of account with existing account ID fails"
+      (f::create-account BOB BOB_KEY))
+
+    ;; fund for testing
+    (fund f BOB 1.0)
+    ;; test ownership
+    (env-sigs
+      [ {"key": ALICE_KEY
+      , "caps": [(f::TRANSFER BOB ALICE 1.0)]}])
+    (with-applied-env
+      (expect-failure
+        "Created account prevents unauthorized transfer"
+        (f::transfer-create BOB ALICE ALICE_GUARD 1.0)))
+
+    (env-sigs
+      [ {"key": BOB_KEY
+      , "caps": [(f::TRANSFER BOB ALICE 1.0)]}])
+    (with-applied-env
+      (expect-that
+        "Created account allows authorized transfer"
+        (constantly true)
+        (f::transfer-create BOB ALICE ALICE_GUARD 1.0)))
+
+    (rollback-tx)
+    true
+  )
+
+
+  (defun transfer-tests (f:module{fungible-v2})
+    " Covers:                                        \
+    \ 1) properties on 'transfer'                    \
+    \ 2) managed capability calculus                 \
+    \ 3) precision violations                        \
+    \ Exceptions:                                    \
+    \ - empty account IDs (covered by create-account \
+    \   and transfer-create tests.)                  "
+
+    (begin-tx "transfer-tests 1")
+
+    (expect-that "Bob account creation succeeds"
+      (constantly true) ;; avoid requiring specific response
+      (f::create-account BOB BOB_GUARD))
+
+    (expect-that "Alice account creation succeeds"
+      (constantly true) ;; avoid requiring specific response
+      (f::create-account ALICE ALICE_GUARD))
+
+    (fund f BOB 1.0)
+
+    (expect-failure
+      "Cannot transfer Bob-Alice without managed capability"
+      "capability not installed" ;; text from Pact, not module
+      (f::transfer BOB ALICE 1.0))
+
+    (fund f ALICE 2.0)
+
+    (expect-failure
+      "Cannot transfer Alice-Bob without managed capability"
+      "capability not installed" ;; text from Pact, not module
+      (f::transfer ALICE BOB 2.0))
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 1.0)]}
+        { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 2.0)]}
+      ])
+    (with-applied-env [
+
+      (expect-failure
+        "Transfer fails with negative amount"
+        (f::transfer BOB ALICE -0.1)
+      )
+
+      (expect-failure
+        "Transfer fails with 0.0 amount"
+        (f::transfer BOB ALICE 0.0)
+      )
+
+      (expect-failure
+        "Transfer fails with min precision / 10 value"
+        (f::transfer BOB ALICE
+          (/ (precision-min-value f) 10.0)))
+
+      (expect-failure
+        "Transfer fails with amount greater than cap"
+        (f::transfer BOB ALICE 10.0)
+      )
+
+      (expect-that
+        "Transfer Bob-Alice succeeds with exact cap"
+        (constantly true)
+        (f::transfer BOB ALICE 1.0))
+
+      (expect
+        "Transfer Bob-Alice: Bob balance correct"
+        0.0
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer Bob-Alice: Alice balance correct"
+        3.0
+        (f::get-balance ALICE))
+
+      (expect-that
+        "Transfer Alice-Bob-1 succeeds with 1/2 cap"
+        (constantly true)
+        (f::transfer ALICE BOB 1.0))
+
+      (expect-failure
+        "Transfer Alice-Bob-2 fails for full cap"
+        (f::transfer ALICE BOB 2.0))
+
+      (expect-that
+        "Transfer Alice-Bob-2 succeeds with 1/2 cap"
+        (constantly true)
+        (f::transfer ALICE BOB 1.0))
+
+      (expect
+        "Transfer Alice-Bob: Bob balance correct"
+        2.0
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer Alice-Bob: Alice balance correct"
+        1.0
+        (f::get-balance ALICE))
+
+    ])
+
+    (rollback-tx)
+
+    (begin-tx "transfer-tests-2")
+
+    (fund-create f BOB BOB_GUARD 1.0)
+    (fund-create f ALICE ALICE_GUARD 1.0)
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer fails without Bob signing"
+        (f::transfer BOB ALICE 1.0))
+    ])
+
+    (rollback-tx)
+
+
+    (begin-tx "transfer-tests-3")
+
+    (fund-create f BOB BOB_GUARD 1.0)
+    (fund-create f ALICE ALICE_GUARD 1.0)
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 5.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer fails for insufficient funds"
+        (f::transfer BOB ALICE 5.0))
+
+      (expect-that
+        "Transfer succeeds for min precision value"
+        (constantly true)
+        (f::transfer BOB ALICE (precision-min-value f)))
+
+      (expect
+        "Transfer min precision: Bob balance correct"
+        (- 1.0 (precision-min-value f))
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer min precision: Alice balance correct"
+        (+ 1.0 (precision-min-value f))
+        (f::get-balance ALICE))
+    ])
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB BOB 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer fails for same account"
+        (f::transfer BOB BOB 1.0))
+    ])
+
+    (rollback-tx)
+    true
+  )
+
+
+
+  (defun transfer-create-tests:bool (f:module{fungible-v2})
+    " Covers:                                        \
+    \ 1) properties on 'transfer-create'             \
+    \ 2) managed capability calculus                 \
+    \ 3) precision violations                        \
+    \ Exceptions:                                    \
+    \ - empty sender ID (covered by create-account tests) "
+
+    (begin-tx "transfer-create-tests 1")
+
+    (fund-create f ALICE ALICE_GUARD 1.0)
+
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE "" 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer-create fails for empty receiver account"
+        (f::transfer-create ALICE "" ALICE_GUARD 1.0))
+      ])
+
+
+    (expect-failure
+      "Cannot transfer-create Alice-Bob without managed capability"
+      "capability not installed" ;; text from Pact, not module
+      (f::transfer-create ALICE BOB BOB_GUARD 1.0))
+
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 1.0)]}
+      ])
+    (with-applied-env [
+
+      (expect-failure
+        "Transfer-create fails with negative amount"
+        (f::transfer-create ALICE BOB BOB_GUARD -0.1)
+      )
+
+      (expect-failure
+        "Transfer-create fails with 0.0 amount"
+        (f::transfer-create ALICE BOB BOB_GUARD 0.0)
+      )
+
+      (expect-failure
+        "Transfer-create fails with min precision / 10 value"
+        (f::transfer-create ALICE BOB BOB_GUARD
+          (/ (precision-min-value f) 10.0)))
+
+      (expect-failure
+        "Transfer-create fails with amount greater than cap"
+        (f::transfer-create ALICE BOB BOB_GUARD 10.0)
+      )
+
+      (expect-that
+        "Transfer-create succeeds Alice-Bob"
+        (constantly true)
+        (f::transfer-create ALICE BOB BOB_GUARD 1.0))
+
+      (expect
+        "Transfer Alice-Bob: Bob balance correct"
+        1.0
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer Alice-Bob: Alice balance correct"
+        0.0
+        (f::get-balance ALICE))
+
+    ])
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 0.1)]}
+      ])
+    (with-applied-env [
+
+      (expect-that
+        "Transfer-create Bob-Alice-1 succeeds with 1/4 cap"
+        (constantly true)
+        (f::transfer-create BOB ALICE ALICE_GUARD 0.025))
+
+      (expect-failure
+        "Transfer-create Bob-Alice-2 fails for full cap"
+        (f::transfer-create BOB ALICE ALICE_GUARD 0.1))
+
+      (expect-that
+        "Transfer-create Bob-Alice-2 succeeds with 1/2 cap"
+        (constantly true)
+        (f::transfer-create BOB ALICE ALICE_GUARD 0.05))
+
+      (expect
+        "Transfer-create Bob-Alice: Bob balance correct"
+        0.925
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer-create Bob-Alice: Alice balance correct"
+        0.075
+        (f::get-balance ALICE))
+
+      (expect-failure
+        "Transfer-create fails with mismatched guard"
+        (f::transfer-create BOB ALICE BOB_GUARD 0.025)
+      )
+
+    ])
+
+    (rollback-tx)
+
+    (begin-tx "transfer-create-tests-2")
+
+    (fund-create f BOB BOB_GUARD 1.0)
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer-create fails without Bob signing"
+        (f::transfer-create BOB ALICE ALICE_GUARD 1.0))
+    ])
+
+    (rollback-tx)
+
+    (begin-tx "transfer-create-tests-3")
+
+    (fund-create f BOB BOB_GUARD 1.0)
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 5.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer-create fails for insufficient funds"
+        (f::transfer-create BOB ALICE ALICE_GUARD 5.0))
+
+      (expect-that
+        "Transfer-create succeeds for min precision value"
+        (constantly true)
+        (f::transfer-create BOB ALICE ALICE_GUARD (precision-min-value f)))
+
+      (expect
+        "Transfer-create min precision: Bob balance correct"
+        (- 1.0 (precision-min-value f))
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer-create min precision: Alice balance correct"
+        (precision-min-value f)
+        (f::get-balance ALICE))
+    ])
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB BOB 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer-create fails for same account"
+        (f::transfer-create BOB BOB BOB_GUARD 1.0))
+    ])
+
+    (rollback-tx)
+    true
+  )
+
+
+  (defun transfer-crosschain-tests:bool (f:module{fungible-v2})
+    " Covers:                                             \
+    \ 1) properties on 'transfer-crosschain'              \
+    \ 2) precision violations                             \
+    \ Exceptions:                                         \
+    \ - bad-same-sender-receiver property in fungible-v2  \
+    \   which is unsound/to be removed                    \
+    \ - empty sender ID (covered by create-account tests) "
+
+    (begin-tx "transfer-crosschain-tests 1")
+    (expect-failure
+      "Cross-chain transfer fails for unknown account"
+      (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 2.0)
+    )
+    (rollback-tx)
+
+    (begin-tx "transfer-crosschain-tests 2")
+    (fund-create f BOB BOB_GUARD 2.0)
+    (expect-failure
+      "Cross-chain transfer fails without signature"
+      (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 2.0)
+    )
+    (rollback-tx)
+
+    (begin-xchain f 3 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails with negative amount"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 -0.1))))
+    (rollback-tx)
+
+    (begin-xchain f 4 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails with 0.0 amount"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 0.0))))
+    (rollback-tx)
+
+    (begin-xchain f 5 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails with min precision / 10 value"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1
+          (/ (precision-min-value f) 10.0)))))
+    (rollback-tx)
+
+    (begin-xchain f 6 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails for empty receiver"
+        (f::transfer-crosschain BOB "" ALICE_GUARD CHAIN_1 1.0))))
+    (rollback-tx)
+
+    (begin-xchain f 7 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails for insufficient funds"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 10.0))))
+    (rollback-tx)
+
+    (begin-xchain f 7 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails to same chain"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD "0" 1.0))))
+    (rollback-tx)
+
+    (begin-xchain f 8 BOB BOB_GUARD BOB_KEY 3.0)
+
+    (with-applied-env (with-capability (XCHAIN)
+
+      (expect-that
+        "Cross-chain transfer succeeds"
+        (constantly true)
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 1.0))
+
+      (expect
+        "Cross-chain transfer: sender balance correct"
+        2.0 (f::get-balance BOB))
+
+      (expect-failure
+        "Cross-chain transfer: receiver not credited on source chain"
+        (f::get-balance ALICE))
+
+      (expect-failure
+        "Resumption on wrong chain fails"
+        "yield provenance" ;; from pact internals
+        (continue-pact 1))
+
+      (env-chain-data { 'chain-id: CHAIN_1 })
+      (with-applied-env [
+        (expect-that
+          "Cross-chain transfer: Resumption on correct chain succeeds"
+          (constantly true)
+          (continue-pact 1))
+
+        (expect-failure
+          "Duplicate resumption of cross-chain prevented"
+          "pact completed" ;; from pact internals
+          (continue-pact 1))
+      ])
+
+    ))
+
+    (expect
+      "Cross-chain transfer: receiver balance correct"
+      1.0 (f::get-balance ALICE))
+
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 0.1)]}
+      ])
+    (with-applied-env
+      (expect-that
+        "Cross-chain transfer: receiver guard correct"
+        (constantly true)
+        (f::transfer ALICE BOB 0.1)))
+
+    (expect
+      "Cross-chain transfer: receiver balance correct after test tfr"
+      0.9 (f::get-balance ALICE))
+
+    (expect
+      "Cross-chain transfer: sender balance correct after test tfr"
+      2.1 (f::get-balance BOB))
+
+    (rollback-tx)
+
+    (begin-xchain f 9 BOB BOB_GUARD BOB_KEY 1.0)
+
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-that
+        "Cross-chain transfer min value succeeds"
+        (constantly true)
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1
+          (precision-min-value f)))
+
+      (env-chain-data { 'chain-id: CHAIN_1 })
+      (with-applied-env
+        (expect-that
+          "Cross-chain transfer min value: Resumption on correct chain succeeds"
+          (constantly true)
+          (continue-pact 1)))))
+
+    (expect
+      "Cross-chain transfer min value: receiver balance correct"
+      (precision-min-value f) (f::get-balance ALICE))
+
+    (expect
+      "Cross-chain transfer min value: sender balance correct"
+      (- 1.0 (precision-min-value f)) (f::get-balance BOB))
+
+    true
+  )
+
+  (defun rotate-tests:bool
+    ( f:module{fungible-v2}
+      h:module{fungible-test-helper}
+    )
+    " Covers rotate semantics, namely that old guard is enforced \
+    \ and new guard verified to be correct."
+
+    (begin-tx "rotate-tests")
+
+    (fund-create f ALICE ALICE_GUARD 100.0)
+
+    (expect-failure
+      "rotate without setup fails"
+      (f::rotate ALICE BOB_GUARD))
+
+
+    (expect-that "pre-rotate bad key succeeds"
+      (constantly true)
+      (if (h::setup-rotate ALICE BOB_KEY) true
+        (env-sigs [{"key": BOB_KEY, "caps": [(ROTATE)]}])))
+
+    (with-applied-env (with-capability (ROTATE)
+      (expect-failure "rotate fails with bad key"
+            (f::rotate ALICE BOB_GUARD))))
+
+    (expect-that "pre-rotate succeeds"
+      (constantly true)
+      (if (h::setup-rotate ALICE ALICE_KEY) true
+        (env-sigs [{"key": ALICE_KEY, "caps": [(ROTATE)]}])))
+
+    (with-applied-env (with-capability (ROTATE)
+      (expect-that "rotate succeeds"
+        (constantly true)
+        (f::rotate ALICE BOB_GUARD))))
+
+
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure "post-rotate transfer fails with old key"
+        (f::transfer-create ALICE BOB BOB_GUARD 0.2))
+      ])
+
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-that "post-rotate transfer succeeds"
+        (constantly true)
+        (f::transfer-create ALICE BOB BOB_GUARD 0.2))
+      ])
+
+    (expect
+      "sender balance correct"
+      99.8 (f::get-balance ALICE))
+
+    (expect
+      "receiver balance correct"
+      0.2 (f::get-balance BOB))
+
+    (rollback-tx)
+    true
+  )
+
+
+  (defun enforce-unit-tests:bool (f:module{fungible-v2})
+    "Strictly covers min precision only."
+    (begin-tx "enforce-unit-tests")
+
+    (expect-that "1.0 succeeds"
+      (f::enforce-unit) 1.0)
+    (expect-that "min precision succeeds"
+      (f::enforce-unit) (precision-min-value f))
+    (expect-failure "min prec / 10 fails"
+      (f::enforce-unit (/ (precision-min-value f) 10.0)))
+
+    (rollback-tx)
+    true
+  )
+)

--- a/pact/test/ledger-test-fungible.pact
+++ b/pact/test/ledger-test-fungible.pact
@@ -1,0 +1,195 @@
+(module ledger-test-fungible G
+  " Module for mocking an individual marmalade token \
+  \ as a standalone 'fungible-v2' for coverage by the fungible \
+  \ test. Note that when Pact gains implicit arguments for \
+  \ modrefs, this will not be needed anymore."
+  (defcap G () true)
+
+  (defconst TOKEN:string "token")
+
+  (implements fungible-v2)
+
+  (defschema entry guard:guard version:integer)
+  (deftable entries:{entry}
+    "Track GUARD and maintain VERSION for delegate guard")
+
+  (defschema caps pending:[object])
+  (deftable capstate:{caps}
+    "Singleton storage for accumulating delegate TRANSFER cap install")
+  (defconst S "SINGLETON")
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce-entry sender)
+    ;; managed caps are called on install, track
+    ;; for delegate install in transfer function
+    (with-default-read capstate S
+      { 'pending: [] }
+      { 'pending := caps }
+      (write capstate S
+        { 'pending: (+ caps
+          [ { 'sender: sender, 'receiver: receiver
+            , 'amount: amount } ]) })
+    )
+  )
+
+  (defun install-pending ()
+    "Install pending delegate TRANSFER caps"
+    (with-default-read capstate S
+      { 'pending: [] }
+      { 'pending := caps }
+      (write capstate S { 'pending: [] })
+      (map (install) caps)
+    )
+  )
+  (defun install (cap:object)
+    (install-capability
+      (marmalade.ledger.TRANSFER TOKEN
+        (at 'sender cap)
+        (at 'receiver cap)
+        (at 'amount cap)
+      ))
+  )
+
+  (defcap DELEGATE (account:string version:integer)
+    "Delegate of user guard to underlying token custody."
+    true)
+
+  (defun enforce-entry:integer (account:string)
+    "Enforce tracked guard and return current delegate version."
+    (let ((e (read entries account)))
+      (enforce-guard (at 'guard e))
+      (at 'version e)
+      )
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+    "All-pass manager so underlying can be tested."
+    requested
+  )
+
+  (defun transfer:string
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    (with-capability (TRANSFER sender receiver amount)
+      (install-pending)
+      (with-capability
+        (DELEGATE sender (at 'version (read entries sender)))
+        (marmalade.ledger.transfer TOKEN sender receiver amount))
+    )
+
+  )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal
+    )
+    (with-capability (TRANSFER sender receiver amount)
+      (install-pending)
+      (with-default-read entries receiver
+        { 'guard: receiver-guard, 'version: 0 }
+        { 'guard := g, 'version:= v }
+        (let
+          ( (del-guard
+              (if (= receiver-guard g)
+                ;; correct case, write and return current delegate
+                (let ((d (delegate-guard receiver v)))
+                  (write entries receiver { 'guard: g, 'version: v })
+                  d)
+                ;; incorrect case, pass invalid delegate to ensure enforcement
+                (delegate-guard receiver (+ 1 v)))) )
+          (with-capability (DELEGATE sender (at 'version (read entries sender)))
+            (marmalade.ledger.transfer-create
+              TOKEN sender receiver del-guard amount))))
+    )
+  )
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal
+    )
+    (step (enforce false "unsupported"))
+  )
+
+  (defun get-balance:decimal
+    ( account:string )
+    (marmalade.ledger.get-balance TOKEN account)
+  )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account: string )
+    (remove "id"
+      (+ { 'guard: (at 'guard (read entries account))}
+        (marmalade.ledger.details TOKEN account)))
+  )
+
+  (defun precision:integer ()
+    (marmalade.ledger.precision TOKEN)
+  )
+
+  (defun enforce-unit:bool
+    ( amount:decimal )
+    (marmalade.ledger.enforce-unit TOKEN amount)
+  )
+
+  (defun delegate-guard (account:string version:integer)
+    (create-user-guard (require-delegate account version))
+  )
+
+  (defun require-delegate (account:string version:integer)
+    (require-capability (DELEGATE account version))
+  )
+
+
+  (defun create-account:string
+    ( account:string
+      guard:guard
+    )
+    (insert entries account { 'guard: guard, 'version: 0 })
+    (marmalade.ledger.create-account TOKEN account (delegate-guard account 0))
+  )
+
+  (defun rotate:string
+    ( account:string
+      new-guard:guard
+    )
+    " Enforces tracked user guard, increments delegate version \
+    \ while calling underlying with old delegate in scope to \
+    \ enforce old guard."
+    (let*
+      ( (v (enforce-entry account))
+        (v1 (+ 1 v))
+      )
+      (write entries account
+        { 'guard: new-guard
+        , 'version: v1
+      })
+      (with-capability (DELEGATE account v)
+        (marmalade.ledger.rotate TOKEN account
+          (delegate-guard account v1)))
+    ))
+
+  (defun test-fund
+    ( account:string guard:guard amount:decimal )
+    (create-account account guard)
+    (marmalade.ledger.credit TOKEN account (delegate-guard account 0) amount)
+    true
+  )
+
+)
+(create-table entries)
+(create-table capstate)

--- a/pact/yaml/testnet/fixed-quote-policy.yaml
+++ b/pact/yaml/testnet/fixed-quote-policy.yaml
@@ -2,10 +2,10 @@ codeFile: ../../fixed-quote-policy.pact
 signers:
   - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
 data:
-  ns: "hft"
+  ns: "marmalade"
   upgrade: false
 networkId: testnet04
-nonce: "install hft.fixed-quote-policy"
+nonce: "install marmalade.fixed-quote-policy"
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"

--- a/pact/yaml/testnet/ledger.yaml
+++ b/pact/yaml/testnet/ledger.yaml
@@ -1,11 +1,11 @@
-codeFile: ../../hft.pact
+codeFile: ../../ledger.pact
 signers:
   - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
 data:
-  ns: "hft"
+  ns: "marmalade"
   upgrade: false
 networkId: testnet04
-nonce: install-hft.hft
+nonce: install-marmalade.ledger
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"

--- a/pact/yaml/testnet/ns-hft.yaml
+++ b/pact/yaml/testnet/ns-hft.yaml
@@ -1,4 +1,4 @@
-codeFile: ../../ns-hft.pact
+codeFile: ../../ns-marmalade.pact
 signers:
   - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
 data:
@@ -16,7 +16,7 @@ data:
       - 5d3dbd0c7e9902de1a868b3410462b034760264c910091f3e0d117397ab394e6
     pred: keys-any
 networkId: testnet04
-nonce: install namespace hft
+nonce: install namespace marmalade
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"

--- a/pact/yaml/testnet/policy.yaml
+++ b/pact/yaml/testnet/policy.yaml
@@ -2,10 +2,10 @@ codeFile: ../../policy.pact
 signers:
   - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
 data:
-  ns: "hft"
+  ns: "marmalade"
   upgrade: false
 networkId: testnet04
-nonce: "install hft.token-policy-v1_DRAFT1 and hft.policy"
+nonce: "install marmalade.policy"
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"

--- a/pact/yaml/testnet/poly-fungible-v2.yaml
+++ b/pact/yaml/testnet/poly-fungible-v2.yaml
@@ -5,7 +5,7 @@ data:
   ns: "kip"
   upgrade: false
 networkId: testnet04
-nonce: "install kip.poly-fungible-v2_DRAFT1"
+nonce: "install kip.poly-fungible-v2_DRAFT2"
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"


### PR DESCRIPTION
- move to `marmalade` namespace, `ledger` module name
- add sale pact and caps to `poly-fungible-v2`
- crosschain policy support
- move token policy to `kip`
- standardize policy naming
- add fungible-v2 test coverage to `ledger`
- move all policy enforcements out of `defcap`s into function bodies
- move guard policy init into `create-token`/`enforce-init`
