### PR TITLE
Verify quote parameters in fixed quote policy 

### DIFF
--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -79,9 +79,9 @@
     )
     @doc "Capture quote spec for SALE of TOKEN from message"
     (enforce-sale-pact sale-id)
-    (let ( (spec:object{quote-spec} (read-msg QUOTE) )
-           (fungible:module{fungible-v2} (at 'fungible (read-msg QUOTE)) )
-           (price:decimal (at 'price (read-msg QUOTE))) )
+    (let* ( (spec:object{quote-spec} (read-msg QUOTE))
+            (fungible:module{fungible-v2} (at 'fungible spec) )
+            (price:decimal (at 'price spec)) )
       (fungible::enforce-unit price)
       (enforce (< 0.0 price) "Offer amount must be positive")
       (insert quotes sale-id { 'id: (at 'id token), 'spec: spec }))

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -79,16 +79,11 @@
     )
     @doc "Capture quote spec for SALE of TOKEN from message"
     (enforce-sale-pact sale-id)
-    (let ( (spec:object{quote-spec} (read-msg QUOTE) ))
-      (bind spec
-        { 'fungible := fungible:module{fungible-v2}
-        , 'price := price:decimal
-        , 'recipient := recipient:string
-        , 'recipient-guard := recipient-guard:guard
-        }
-        (fungible::precision)
-        (enforce (< 0.0 price) "Offer amount must be positive")
-        )
+    (let ( (spec:object{quote-spec} (read-msg QUOTE) )
+           (fungible:module{fungible-v2} (at 'fungible (read-msg QUOTE)) )
+           (price:decimal (at 'price (read-msg QUOTE))) )
+      (fungible::enforce-unit price)
+      (enforce (< 0.0 price) "Offer amount must be positive")
       (insert quotes sale-id { 'id: (at 'id token), 'spec: spec }))
   )
 

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -79,7 +79,16 @@
     )
     @doc "Capture quote spec for SALE of TOKEN from message"
     (enforce-sale-pact sale-id)
-    (let ( (spec:object{quote-spec} (read-msg QUOTE) ) )
+    (let ( (spec:object{quote-spec} (read-msg QUOTE) ))
+      (bind spec
+        { 'fungible := fungible:module{fungible-v2}
+        , 'price := price:decimal
+        , 'recipient := recipient:string
+        , 'recipient-guard := recipient-guard:guard
+        }
+        (fungible::precision)
+        (enforce (< 0.0 price) "Offer amount must be positive")
+        )
       (insert quotes sale-id { 'id: (at 'id token), 'spec: spec }))
   )
 

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -81,9 +81,15 @@
     (enforce-sale-pact sale-id)
     (let* ( (spec:object{quote-spec} (read-msg QUOTE))
             (fungible:module{fungible-v2} (at 'fungible spec) )
-            (price:decimal (at 'price spec)) )
+            (price:decimal (at 'price spec))
+            (recipient:string (at 'recipient spec))
+            (recipient-guard:guard (at 'recipient-guard spec))
+            (recipient-details:object (fungible::details recipient)) )
       (fungible::enforce-unit price)
       (enforce (< 0.0 price) "Offer amount must be positive")
+      (enforce (=
+        (at 'guard recipient-details) recipient-guard)
+        "Recipient guard does not match")
       (insert quotes sale-id { 'id: (at 'id token), 'spec: spec }))
   )
 

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -595,6 +595,42 @@
  ])
 
 (env-data
+ {
+  "quote": {
+      "fungible": coin
+     ,"price": 1.0
+     ,"recipient": "alice"
+     ,"recipient-guard": {"keys": ["alice"], "pred":"="}
+   }
+ })
+
+(expect-failure
+  "Sale fails with non-existent recipient account"
+  "Failure: Tx Failed: with-read: row not found: alice"
+  (sale 'project-2 'bob 0.2 120))
+
+(env-data
+  {
+   "quote": {
+       "fungible": coin
+      ,"price": 1.0
+      ,"recipient": "alice"
+      ,"recipient-guard": {"keys": ["wrong-alice"], "pred":"="}
+    }
+  ,"alice": {"keys": ["alice"], "pred":"="}
+ })
+
+(expect
+  "Create recipient account alice"
+  "Write succeeded"
+  (coin.create-account 'alice (read-keyset 'alice)))
+
+(expect-failure
+  "Sale fails with wrong recipient guard"
+  "Failure: Tx Failed: Recipient guard does not match"
+  (sale 'project-2 'bob 0.2 120))
+
+(env-data
   {
    "quote": {
        "fungible": ns
@@ -656,10 +692,16 @@
 
 (rollback-tx)
 
-
 (begin-tx "sale fixed-quote-policy success")
 (env-hash (hash "fixed-quote-sale-tx2"))
 (use marmalade.ledger)
+
+(env-data {"alice": {"keys": ["alice"], "pred":"="}})
+(expect
+  "Create recipient account alice"
+  "Write succeeded"
+  (coin.create-account 'alice (read-keyset 'alice)))
+
 (env-sigs
   [{'key:'bob
    ,'caps:
@@ -758,9 +800,15 @@
 (rollback-tx)
 
 (begin-tx "sale fixed-quote-policy timeout/withdraw")
-(begin-tx "sale fixed-quote-policy success")
 (env-hash (hash "fixed-quote-sale-tx3"))
 (use marmalade.ledger)
+
+(env-data {"alice": {"keys": ["alice"], "pred":"="}})
+(expect
+  "Create recipient account alice"
+  "Write succeeded"
+  (coin.create-account 'alice (read-keyset 'alice)))
+
 (env-sigs
   [{'key:'bob
    ,'caps:
@@ -830,6 +878,10 @@
 (expect "coin-buyer's coin balance remains unchanged"
   2.0
   (coin.get-balance 'coin-buyer))
+
+(expect "recipient's coin balance remains unchanged"
+  0.0
+  (coin.get-balance 'alice))
 
 (expect-failure "Withdraw fails after sale completes"
   (format "pact completed: {}" [(pact-id)])

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -593,11 +593,8 @@
 (env-data
   {
    "quote": {
-       "fungible": {
-         "refName": {"namespace": "null", "name": coin},
-         "refSpec": {"namepace": "null", "name": fungible-v2}
-       }
-      ,"price": -1.0
+       "fungible": kip.token-manifest
+      ,"price": 1.0
       ,"recipient": "alice"
       ,"recipient-guard": {"keys": ["alice"], "pred":"="}
     }

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -580,6 +580,82 @@
 
 (commit-tx)
 
+(begin-tx "sale fixed-quote-policy failure")
+(env-hash (hash "fixed-quote-sale-tx2"))
+(use marmalade.ledger)
+(env-chain-data {"block-height": 100})
+(env-sigs
+  [{'key:'bob
+   ,'caps:
+    [(marmalade.ledger.OFFER "project-2" "bob" 0.2 120)]}
+ ])
+
+(env-data
+  {
+   "quote": {
+       "fungible": {
+         "refName": {"namespace": "null", "name": coin},
+         "refSpec": {"namepace": "null", "name": fungible-v2}
+       }
+      ,"price": -1.0
+      ,"recipient": "alice"
+      ,"recipient-guard": {"keys": ["alice"], "pred":"="}
+    }
+  })
+
+(expect-failure
+  "Sale fails with non-fungible in quote"
+  "fungible: Failure: Type error: expected module{fungible-v2}, found object:*"
+  (sale 'project-2 'bob 0.2 120))
+
+(env-data
+  {
+   "quote": {
+       "fungible": coin
+      ,"price": -1.0
+      ,"recipient": "alice"
+      ,"recipient-guard": {"keys": ["alice"], "pred":"="}
+    }
+  })
+
+(expect-failure
+  "Sale fails with negative price in quote"
+  "Offer amount must be positive"
+  (sale 'project-2 'bob 0.2 120))
+
+(env-data
+  {
+   "quote": {
+       "fungible": coin
+      ,"price": 1.0
+      ,"recipient": {"account": "alice"}
+      ,"recipient-guard":  {"keys": ["alice"], "pred":"="}
+    }
+  })
+
+(expect-failure
+  "Sale fails with invalid recipient in quote"
+  "Type error: expected string, found object:*"
+  (sale 'project-2 'bob 0.2 120))
+
+(env-data
+  {
+   "quote": {
+       "fungible": coin
+      ,"price": 1.0
+      ,"recipient": "alice"
+      ,"recipient-guard": "INVALID GUARD"
+    }
+  })
+
+(expect-failure
+  "Sale fails with invalid guard in quote"
+  "Type error: expected guard, found string"
+  (sale 'project-2 'bob 0.2 120))
+
+(rollback-tx)
+
+
 (begin-tx "sale fixed-quote-policy success")
 (env-hash (hash "fixed-quote-sale-tx2"))
 (use marmalade.ledger)

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -1,8 +1,12 @@
 (begin-tx)
-
+(env-data
+  { 'ns-admin-keyset: []
+  , 'ns-genesis-keyset:[]
+  , 'ns-operate-keyset:[] })
 (load "root/fungible-v2.pact")
 (load "root/gas-payer-v1.pact")
 (load "root/coin.pact")
+(load "root/ns.pact")
 
 (define-namespace 'kip (sig-keyset) (sig-keyset))
 
@@ -593,7 +597,7 @@
 (env-data
   {
    "quote": {
-       "fungible": kip.token-manifest
+       "fungible": ns
       ,"price": 1.0
       ,"recipient": "alice"
       ,"recipient-guard": {"keys": ["alice"], "pred":"="}
@@ -602,7 +606,7 @@
 
 (expect-failure
   "Sale fails with non-fungible in quote"
-  "fungible: Failure: Type error: expected module{fungible-v2}, found object:*"
+  "fungible: Failure: Type error: expected module{fungible-v2}, found module{}"
   (sale 'project-2 'bob 0.2 120))
 
 (env-data

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -660,36 +660,6 @@
   "Offer amount must be positive"
   (sale 'project-2 'bob 0.2 120))
 
-(env-data
-  {
-   "quote": {
-       "fungible": coin
-      ,"price": 1.0
-      ,"recipient": {"account": "alice"}
-      ,"recipient-guard":  {"keys": ["alice"], "pred":"="}
-    }
-  })
-
-(expect-failure
-  "Sale fails with invalid recipient in quote"
-  "Type error: expected string, found object:*"
-  (sale 'project-2 'bob 0.2 120))
-
-(env-data
-  {
-   "quote": {
-       "fungible": coin
-      ,"price": 1.0
-      ,"recipient": "alice"
-      ,"recipient-guard": "INVALID GUARD"
-    }
-  })
-
-(expect-failure
-  "Sale fails with invalid guard in quote"
-  "Type error: expected guard, found string"
-  (sale 'project-2 'bob 0.2 120))
-
 (rollback-tx)
 
 (begin-tx "sale fixed-quote-policy success")


### PR DESCRIPTION
When running `enforce-offer`, verify that price is positive, and that module exists. 
Also considered recipient check, but `k:` accounts can prevent squatting, so didn't add it. @sirlensalot thoughts? 

Fixes #14 