### PR TITLE
Remove dummy implementation

### DIFF
--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -144,14 +144,6 @@
     (enforce-ledger)
     (enforce false "Transfer prohibited")
   )
-
-  ;; dummy impl to address #928
-  (implements gas-payer-v1)
-  (defcap GAS_PAYER:bool
-    ( user:string limit:integer price:decimal )
-    (enforce false "Dummy implementation"))
-  (defun create-gas-payer-guard:guard ()
-    (enforce false "Dummy implementation"))
 )
 
 

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -101,15 +101,6 @@
     (enforce-ledger)
     (enforce-guard (at 'transfer-guard (get-guards token)))
   )
-
-  ;; dummy impl to address #928
-  (implements gas-payer-v1)
-  (defcap GAS_PAYER:bool
-    ( user:string limit:integer price:decimal )
-    (enforce false "Dummy implementation"))
-  (defun create-gas-payer-guard:guard ()
-    (enforce false "Dummy implementation"))
-
 )
 
 (if (read-msg 'upgrade)


### PR DESCRIPTION
- Remove implementation of gas payer as a workaround after pact upgrade 2.12.  kadena-io/pact/issues/928