### PR TITLE
Change datum input to a text field

### DIFF
--- a/src/HFT/Manifest.js
+++ b/src/HFT/Manifest.js
@@ -121,7 +121,7 @@ export const RenderManifest = ({mfCache}) => {
     keyOrder={["hash","contents"]}
     kvFunc={
       {'contents': v => {
-        return <ReactJson 
+        return <ReactJson
           src={v.contents}
           name={false}
           collapsed={2}
@@ -233,7 +233,6 @@ const CreateDatum = ({mfCache, setMfCache}) => {
       type:'textFieldMulti',
       label:'Datum',
       className:classes.formControl,
-      options:_.map(_.reject(mfCache,{type:'datum'}),v=> JSON.stringify(v.value)),
       value:datum,
       onChange:setDatum
     }

--- a/src/HFT/Manifest.js
+++ b/src/HFT/Manifest.js
@@ -1,6 +1,6 @@
 //basic React api imports
 import React, { useState, useEffect } from "react";
-import { 
+import {
   useQueryParams,
   StringParam,
  } from 'use-query-params';
@@ -145,7 +145,7 @@ export const RenderDatum = ({mfCache}) => {
     keyOrder={["hash","contents"]}
     kvFunc={
       {'contents': v => {
-        return <ReactJson 
+        return <ReactJson
           src={v.contents}
           name={false}
           collapsed={2}
@@ -230,8 +230,8 @@ const CreateDatum = ({mfCache, setMfCache}) => {
       onChange:setUri
     },
     {
-      type:'select',
-      label:'Data',
+      type:'textFieldMulti',
+      label:'Datum',
       className:classes.formControl,
       options:_.map(_.reject(mfCache,{type:'datum'}),v=> JSON.stringify(v.value)),
       value:datum,


### PR DESCRIPTION
In the manifest page, create-datum allows user to select datum from a list of cached objects. 
Instead, the input should be a text field where users can paste in a custom object.
https://github.com/kadena-io/marmalade/blob/db7c0a3cdfd4966e1cc282e5d4447a01503abc71/pact/kip/manifest.pact#L42-L50