### PR TITLE
add guard argument to policy ops

### DIFF
--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -61,7 +61,6 @@
   (defun enforce-burn:bool
     ( token:object{token-info}
       account:string
-      guard:guard
       amount:decimal
     )
     (enforce-ledger)

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -7,8 +7,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
 
-  (implements kip.token-policy-v1_DRAFT3)
-  (use kip.token-policy-v1_DRAFT3 [token-info])
+  (implements kip.token-policy-v1_DRAFT4)
+  (use kip.token-policy-v1_DRAFT4 [token-info])
 
   (defschema policy-schema
     mint-guard:guard

--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -46,6 +46,7 @@
   (defun enforce-mint:bool
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
     )
     (enforce-ledger)
@@ -60,6 +61,7 @@
   (defun enforce-burn:bool
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
     )
     (enforce-ledger)
@@ -129,6 +131,7 @@
   (defun enforce-transfer:bool
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       amount:decimal )
     (enforce-ledger)
@@ -138,6 +141,7 @@
   (defun enforce-crosschain:bool
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       target-chain:string
       amount:decimal )

--- a/pact/fixed-quote-royalty-policy.pact
+++ b/pact/fixed-quote-royalty-policy.pact
@@ -7,8 +7,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-ns-admin )))
 
-  (implements kip.token-policy-v1_DRAFT3)
-  (use kip.token-policy-v1_DRAFT3 [token-info])
+  (implements kip.token-policy-v1_DRAFT4)
+  (use kip.token-policy-v1_DRAFT4 [token-info])
 
   (defschema policy-schema
     fungible:module{fungible-v2}

--- a/pact/fixed-quote-royalty-policy.pact
+++ b/pact/fixed-quote-royalty-policy.pact
@@ -67,7 +67,6 @@
   (defun enforce-burn:bool
     ( token:object{token-info}
       account:string
-      guard:guard
       amount:decimal
     )
     (enforce-ledger)

--- a/pact/fixed-quote-royalty-policy.pact
+++ b/pact/fixed-quote-royalty-policy.pact
@@ -52,6 +52,7 @@
   (defun enforce-mint:bool
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
     )
     (enforce-ledger)
@@ -66,6 +67,7 @@
   (defun enforce-burn:bool
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
     )
     (enforce-ledger)
@@ -167,6 +169,7 @@
   (defun enforce-transfer:bool
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       amount:decimal )
     (enforce-ledger)
@@ -176,6 +179,7 @@
   (defun enforce-crosschain:bool
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       target-chain:string
       amount:decimal )

--- a/pact/kip/token-policy-v1.pact
+++ b/pact/kip/token-policy-v1.pact
@@ -24,7 +24,6 @@
   (defun enforce-burn:bool
     ( token:object{token-info}
       account:string
-      guard:guard
       amount:decimal
     )
     @doc "Burning policy for TOKEN to ACCOUNT for AMOUNT."

--- a/pact/kip/token-policy-v1.pact
+++ b/pact/kip/token-policy-v1.pact
@@ -11,6 +11,7 @@
   (defun enforce-mint:bool
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
     )
     @doc "Minting policy for TOKEN to ACCOUNT for AMOUNT."
@@ -23,6 +24,7 @@
   (defun enforce-burn:bool
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
     )
     @doc "Burning policy for TOKEN to ACCOUNT for AMOUNT."
@@ -58,6 +60,7 @@
   (defun enforce-transfer:bool
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       amount:decimal )
     @doc " Enforce rules on transfer of TOKEN AMOUNT from SENDER to RECEIVER. \
@@ -67,6 +70,7 @@
   (defun enforce-crosschain:bool
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       target-chain:string
       amount:decimal )

--- a/pact/kip/token-policy-v1.pact
+++ b/pact/kip/token-policy-v1.pact
@@ -1,6 +1,6 @@
 (namespace 'kip)
 
-(interface token-policy-v1_DRAFT3
+(interface token-policy-v1_DRAFT4
 
   (defschema token-info
     id:string

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -109,7 +109,7 @@
     (compose-capability (DEBIT id account))
     (compose-capability (UPDATE_SUPPLY))
   )
-  
+
   (defun ledger-guard:guard ()
     @doc "Ledger module guard for policies to be able to validate access to policy operations."
     (create-module-guard "ledger-guard")
@@ -227,7 +227,7 @@
     (bind (get-policy-info id)
       { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
       , 'token := token }
-      (policy::enforce-transfer token sender receiver amount))
+      (policy::enforce-transfer token sender (account-guard id sender) receiver amount))
   )
 
   (defun transfer-create:string
@@ -257,7 +257,7 @@
       (bind (get-policy-info id)
         { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
         , 'token := token }
-        (policy::enforce-mint token account amount))
+        (policy::enforce-mint token account guard amount))
       (credit id account guard amount)
       (update-supply id amount))
   )
@@ -271,7 +271,7 @@
       (bind (get-policy-info id)
         { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
         , 'token := token }
-        (policy::enforce-burn token account amount))
+        (policy::enforce-burn token account (account-guard id account) amount))
       (debit id account amount)
       (update-supply id (- amount)))
   )

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -271,7 +271,7 @@
       (bind (get-policy-info id)
         { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
         , 'token := token }
-        (policy::enforce-burn token account (account-guard id account) amount))
+        (policy::enforce-burn token account amount))
       (debit id account amount)
       (update-supply id (- amount)))
   )

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -25,7 +25,7 @@
     manifest:object{manifest}
     precision:integer
     supply:decimal
-    policy:module{kip.token-policy-v1_DRAFT3}
+    policy:module{kip.token-policy-v1_DRAFT4}
   )
 
   (deftable tokens:{token-schema})
@@ -116,13 +116,13 @@
   )
 
   (defschema policy-info
-    policy:module{kip.token-policy-v1_DRAFT3}
-    token:object{kip.token-policy-v1_DRAFT3.token-info}
+    policy:module{kip.token-policy-v1_DRAFT4}
+    token:object{kip.token-policy-v1_DRAFT4.token-info}
   )
 
   (defun get-policy-info:object{policy-info} (id:string)
     (with-read tokens id
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
+      { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
       , 'supply := supply
       , 'precision := precision
       , 'manifest := manifest
@@ -162,7 +162,7 @@
     ( id:string
       precision:integer
       manifest:object{manifest}
-      policy:module{kip.token-policy-v1_DRAFT3}
+      policy:module{kip.token-policy-v1_DRAFT4}
     )
     (enforce-verify-manifest manifest)
     (policy::enforce-init
@@ -225,7 +225,7 @@
       amount:decimal
     )
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
+      { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
       , 'token := token }
       (policy::enforce-transfer token sender (account-guard id sender) receiver amount))
   )
@@ -255,7 +255,7 @@
     )
     (with-capability (MINT id account amount)
       (bind (get-policy-info id)
-        { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
+        { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
         , 'token := token }
         (policy::enforce-mint token account guard amount))
       (credit id account guard amount)
@@ -269,7 +269,7 @@
     )
     (with-capability (BURN id account amount)
       (bind (get-policy-info id)
-        { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
+        { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
         , 'token := token }
         (policy::enforce-burn token account (account-guard id account) amount))
       (debit id account amount)
@@ -470,7 +470,7 @@
     @doc "Initiate sale with by SELLER by escrowing AMOUNT of TOKEN until TIMEOUT."
     (require-capability (SALE_PRIVATE (pact-id)))
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
+      { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
       , 'token := token }
       (policy::enforce-offer token seller amount (pact-id)))
     (debit id seller amount)
@@ -502,7 +502,7 @@
     @doc "Complete sale with transfer."
     (require-capability (SALE_PRIVATE (pact-id)))
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT3}
+      { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
       , 'token := token }
       (policy::enforce-buy token seller buyer amount sale-id))
     (debit id (sale-account) amount)

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -94,11 +94,10 @@
   (defun burn:string
     ( token:object{token-info}
       account:string
-      guard:guard
       amount:decimal
       policy:module{kip.token-policy-v1_DRAFT4}
     )
-    (policy::enforce-burn token account guard amount)
+    (policy::enforce-burn token account amount)
   )
 
   (defun offer
@@ -185,7 +184,7 @@
     "precision": 12,
     "manifest": (create-manifest (uri "text" "project-0-uri") [])
   }
-  "bob" (read-keyset 'bob-guard) 5.0 marmalade.guard-token-policy))
+  "bob" 5.0 marmalade.guard-token-policy))
 
 (expect-failure
   "enforce-offer is called from an external ledger"

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -62,6 +62,10 @@
 ;; enforce-ledger test
 (begin-tx)
 
+(env-data {
+  "bob-guard": {"keys": ["bob"], "pred": "keys-all"}
+  })
+
 (module test-ledger G
   (defcap G () true)
   (use kip.token-manifest)
@@ -80,19 +84,21 @@
   (defun mint:string
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
       policy:module{kip.token-policy-v1_DRAFT3}
     )
-    (policy::enforce-mint token account amount)
+    (policy::enforce-mint token account guard amount)
   )
 
   (defun burn:string
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
       policy:module{kip.token-policy-v1_DRAFT3}
     )
-    (policy::enforce-burn token account amount)
+    (policy::enforce-burn token account guard amount)
   )
 
   (defun offer
@@ -118,21 +124,23 @@
   (defun enforce-transfer-policy
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       amount:decimal
       policy:module{kip.token-policy-v1_DRAFT3}
     )
-    (policy::enforce-transfer token sender receiver amount)
+    (policy::enforce-transfer token sender guard receiver amount)
   )
 
   (defun transfer-crosschain
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       amount:decimal
       policy:module{kip.token-policy-v1_DRAFT3}
     )
-    (policy::enforce-transfer token sender receiver amount)
+    (policy::enforce-transfer token sender guard receiver amount)
   )
 )
 
@@ -165,7 +173,7 @@
     "precision": 12,
     "manifest": (create-manifest (uri "text" "project-0-uri") [])
   }
-  "bob" 5.0 marmalade.guard-token-policy))
+  "bob" (read-keyset 'bob-guard) 5.0 marmalade.guard-token-policy))
 
 (expect-failure
   "enforce-burn is called from an external ledger"
@@ -177,7 +185,7 @@
     "precision": 12,
     "manifest": (create-manifest (uri "text" "project-0-uri") [])
   }
-  "bob" 5.0 marmalade.guard-token-policy))
+  "bob" (read-keyset 'bob-guard) 5.0 marmalade.guard-token-policy))
 
 (expect-failure
   "enforce-offer is called from an external ledger"
@@ -213,7 +221,7 @@
     "precision": 12,
     "manifest": (create-manifest (uri "text" "project-0-uri") [])
   }
-  "bob" "alice" 5.0 marmalade.guard-token-policy ))
+  "bob" (read-keyset 'bob-guard) "alice" 5.0 marmalade.guard-token-policy ))
 
 (expect-failure
   "enforce-crosschain is called from an external ledger"
@@ -225,7 +233,7 @@
     "precision": 12,
     "manifest": (create-manifest (uri "text" "project-0-uri") [])
   }
-  "bob" "alice" 5.0 marmalade.guard-token-policy ))
+  "bob" (read-keyset 'bob-guard) "alice" 5.0 marmalade.guard-token-policy ))
 
 (rollback-tx)
 

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -69,13 +69,13 @@
 (module test-ledger G
   (defcap G () true)
   (use kip.token-manifest)
-  (use kip.token-policy-v1_DRAFT3 [token-info])
+  (use kip.token-policy-v1_DRAFT4 [token-info])
 
   (defun create-token
     ( id:string
       precision:integer
       manifest:object{manifest}
-      policy:module{kip.token-policy-v1_DRAFT3}
+      policy:module{kip.token-policy-v1_DRAFT4}
     )
     (policy::enforce-init
       { 'id: id, 'supply: 0.0, 'precision: precision, 'manifest: manifest })
@@ -86,7 +86,7 @@
       account:string
       guard:guard
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT3}
+      policy:module{kip.token-policy-v1_DRAFT4}
     )
     (policy::enforce-mint token account guard amount)
   )
@@ -96,7 +96,7 @@
       account:string
       guard:guard
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT3}
+      policy:module{kip.token-policy-v1_DRAFT4}
     )
     (policy::enforce-burn token account guard amount)
   )
@@ -105,7 +105,7 @@
     ( token:object{token-info}
       seller:string
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT3}
+      policy:module{kip.token-policy-v1_DRAFT4}
     )
     (policy::enforce-offer token seller amount "sale")
   )
@@ -116,7 +116,7 @@
       buyer:string
       amount:decimal
       sale-id:string
-      policy:module{kip.token-policy-v1_DRAFT3}
+      policy:module{kip.token-policy-v1_DRAFT4}
     )
     (policy::enforce-buy token seller buyer amount sale-id)
   )
@@ -127,7 +127,7 @@
       guard:guard
       receiver:string
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT3}
+      policy:module{kip.token-policy-v1_DRAFT4}
     )
     (policy::enforce-transfer token sender guard receiver amount)
   )
@@ -138,7 +138,7 @@
       guard:guard
       receiver:string
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT3}
+      policy:module{kip.token-policy-v1_DRAFT4}
     )
     (policy::enforce-transfer token sender guard receiver amount)
   )

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -6,8 +6,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
 
-  (implements kip.token-policy-v1_DRAFT3)
-  (use kip.token-policy-v1_DRAFT3 [token-info])
+  (implements kip.token-policy-v1_DRAFT4)
+  (use kip.token-policy-v1_DRAFT4 [token-info])
 
   (defschema guards
     mint-guard:guard

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -29,6 +29,7 @@
   (defun enforce-mint:bool
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
     )
     (enforce-ledger)
@@ -38,6 +39,7 @@
   (defun enforce-burn:bool
     ( token:object{token-info}
       account:string
+      guard:guard
       amount:decimal
     )
     (enforce-ledger)
@@ -86,6 +88,7 @@
   (defun enforce-transfer:bool
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       amount:decimal )
     (enforce-ledger)
@@ -95,6 +98,7 @@
   (defun enforce-crosschain:bool
     ( token:object{token-info}
       sender:string
+      guard:guard
       receiver:string
       target-chain:string
       amount:decimal )

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -39,7 +39,6 @@
   (defun enforce-burn:bool
     ( token:object{token-info}
       account:string
-      guard:guard
       amount:decimal
     )
     (enforce-ledger)


### PR DESCRIPTION
Upgrades `token-policy-v1-DRAFT3` interface to `token-policy-DRAFT4`, adding `guard` argument in policy ops: 
- enforce-mint
- enforce-transfer
- enforce-transfer-crosschain

Resolves #32 