### PR TITLE
Upgrade to token-policy-v1

### DIFF
--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -7,8 +7,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
 
-  (implements kip.token-policy-v1_DRAFT4)
-  (use kip.token-policy-v1_DRAFT4 [token-info])
+  (implements kip.token-policy-v1)
+  (use kip.token-policy-v1 [token-info])
 
   (defschema policy-schema
     mint-guard:guard

--- a/pact/fixed-quote-royalty-policy.pact
+++ b/pact/fixed-quote-royalty-policy.pact
@@ -7,8 +7,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-ns-admin )))
 
-  (implements kip.token-policy-v1_DRAFT4)
-  (use kip.token-policy-v1_DRAFT4 [token-info])
+  (implements kip.token-policy-v1)
+  (use kip.token-policy-v1 [token-info])
 
   (defschema policy-schema
     fungible:module{fungible-v2}

--- a/pact/kip/account-protocols-v1.pact
+++ b/pact/kip/account-protocols-v1.pact
@@ -1,5 +1,5 @@
 (namespace 'kip)
-(interface account-protocols-v1_DRAFT1
+(interface account-protocols-v1
 
   " Define a standard for support of Kadena Account Protocols, \
   \ which reserve account names starting with 'X:'' where X is a \

--- a/pact/kip/poly-fungible-v2.pact
+++ b/pact/kip/poly-fungible-v2.pact
@@ -2,7 +2,7 @@
 
 (namespace 'kip)
 
-(interface poly-fungible-v2_DRAFT3
+(interface poly-fungible-v2
 
   (defschema account-details
     @doc

--- a/pact/kip/token-policy-v1.pact
+++ b/pact/kip/token-policy-v1.pact
@@ -1,6 +1,6 @@
 (namespace 'kip)
 
-(interface token-policy-v1_DRAFT4
+(interface token-policy-v1
 
   (defschema token-info
     id:string

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -11,8 +11,8 @@
   (use util.fungible-util)
   (use kip.token-manifest)
 
-  (implements kip.poly-fungible-v2_DRAFT3)
-  (use kip.poly-fungible-v2_DRAFT3 [account-details])
+  (implements kip.poly-fungible-v2)
+  (use kip.poly-fungible-v2 [account-details])
 
   ;;
   ;; Tables/Schemas

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -25,7 +25,7 @@
     manifest:object{manifest}
     precision:integer
     supply:decimal
-    policy:module{kip.token-policy-v1_DRAFT4}
+    policy:module{kip.token-policy-v1}
   )
 
   (deftable tokens:{token-schema})
@@ -116,13 +116,13 @@
   )
 
   (defschema policy-info
-    policy:module{kip.token-policy-v1_DRAFT4}
-    token:object{kip.token-policy-v1_DRAFT4.token-info}
+    policy:module{kip.token-policy-v1}
+    token:object{kip.token-policy-v1.token-info}
   )
 
   (defun get-policy-info:object{policy-info} (id:string)
     (with-read tokens id
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
+      { 'policy := policy:module{kip.token-policy-v1}
       , 'supply := supply
       , 'precision := precision
       , 'manifest := manifest
@@ -162,7 +162,7 @@
     ( id:string
       precision:integer
       manifest:object{manifest}
-      policy:module{kip.token-policy-v1_DRAFT4}
+      policy:module{kip.token-policy-v1}
     )
     (enforce-verify-manifest manifest)
     (policy::enforce-init
@@ -225,7 +225,7 @@
       amount:decimal
     )
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
+      { 'policy := policy:module{kip.token-policy-v1}
       , 'token := token }
       (policy::enforce-transfer token sender (account-guard id sender) receiver amount))
   )
@@ -255,7 +255,7 @@
     )
     (with-capability (MINT id account amount)
       (bind (get-policy-info id)
-        { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
+        { 'policy := policy:module{kip.token-policy-v1}
         , 'token := token }
         (policy::enforce-mint token account guard amount))
       (credit id account guard amount)
@@ -269,7 +269,7 @@
     )
     (with-capability (BURN id account amount)
       (bind (get-policy-info id)
-        { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
+        { 'policy := policy:module{kip.token-policy-v1}
         , 'token := token }
         (policy::enforce-burn token account amount))
       (debit id account amount)
@@ -470,7 +470,7 @@
     @doc "Initiate sale with by SELLER by escrowing AMOUNT of TOKEN until TIMEOUT."
     (require-capability (SALE_PRIVATE (pact-id)))
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
+      { 'policy := policy:module{kip.token-policy-v1}
       , 'token := token }
       (policy::enforce-offer token seller amount (pact-id)))
     (debit id seller amount)
@@ -502,7 +502,7 @@
     @doc "Complete sale with transfer."
     (require-capability (SALE_PRIVATE (pact-id)))
     (bind (get-policy-info id)
-      { 'policy := policy:module{kip.token-policy-v1_DRAFT4}
+      { 'policy := policy:module{kip.token-policy-v1}
       , 'token := token }
       (policy::enforce-buy token seller buyer amount sale-id))
     (debit id (sale-account) amount)

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -69,13 +69,13 @@
 (module test-ledger G
   (defcap G () true)
   (use kip.token-manifest)
-  (use kip.token-policy-v1_DRAFT4 [token-info])
+  (use kip.token-policy-v1 [token-info])
 
   (defun create-token
     ( id:string
       precision:integer
       manifest:object{manifest}
-      policy:module{kip.token-policy-v1_DRAFT4}
+      policy:module{kip.token-policy-v1}
     )
     (policy::enforce-init
       { 'id: id, 'supply: 0.0, 'precision: precision, 'manifest: manifest })
@@ -86,7 +86,7 @@
       account:string
       guard:guard
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT4}
+      policy:module{kip.token-policy-v1}
     )
     (policy::enforce-mint token account guard amount)
   )
@@ -95,7 +95,7 @@
     ( token:object{token-info}
       account:string
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT4}
+      policy:module{kip.token-policy-v1}
     )
     (policy::enforce-burn token account amount)
   )
@@ -104,7 +104,7 @@
     ( token:object{token-info}
       seller:string
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT4}
+      policy:module{kip.token-policy-v1}
     )
     (policy::enforce-offer token seller amount "sale")
   )
@@ -115,7 +115,7 @@
       buyer:string
       amount:decimal
       sale-id:string
-      policy:module{kip.token-policy-v1_DRAFT4}
+      policy:module{kip.token-policy-v1}
     )
     (policy::enforce-buy token seller buyer amount sale-id)
   )
@@ -126,7 +126,7 @@
       guard:guard
       receiver:string
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT4}
+      policy:module{kip.token-policy-v1}
     )
     (policy::enforce-transfer token sender guard receiver amount)
   )
@@ -137,7 +137,7 @@
       guard:guard
       receiver:string
       amount:decimal
-      policy:module{kip.token-policy-v1_DRAFT4}
+      policy:module{kip.token-policy-v1}
     )
     (policy::enforce-transfer token sender guard receiver amount)
   )

--- a/pact/policy.pact
+++ b/pact/policy.pact
@@ -6,8 +6,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
 
-  (implements kip.token-policy-v1_DRAFT4)
-  (use kip.token-policy-v1_DRAFT4 [token-info])
+  (implements kip.token-policy-v1)
+  (use kip.token-policy-v1 [token-info])
 
   (defschema guards
     mint-guard:guard

--- a/pact/util/fungible-util.pact
+++ b/pact/util/fungible-util.pact
@@ -1,7 +1,7 @@
 (namespace 'util)
 
 (module fungible-util GOVERNANCE
-  (implements kip.account-protocols-v1_DRAFT1)
+  (implements kip.account-protocols-v1)
 
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'util-ns-admin)))

--- a/pact/yaml/testnet/account-protocols-v1.yaml
+++ b/pact/yaml/testnet/account-protocols-v1.yaml
@@ -5,7 +5,7 @@ data:
   ns: "kip"
   upgrade: false
 networkId: testnet04
-nonce: "0"
+nonce: "install account-protocols-v1 interface"
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"

--- a/pact/yaml/testnet/poly-fungible-v2.yaml
+++ b/pact/yaml/testnet/poly-fungible-v2.yaml
@@ -4,7 +4,7 @@ signers:
 data:
   ns: "kip"
 networkId: testnet04
-nonce: "install kip.poly-fungible-v2_DRAFT2"
+nonce: "install kip.poly-fungible-v2"
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"

--- a/pact/yaml/testnet/token-policy-v1.yaml
+++ b/pact/yaml/testnet/token-policy-v1.yaml
@@ -4,7 +4,7 @@ signers:
 data:
   ns: "kip"
 networkId: testnet04
-nonce: "install kip.token-policy-v1_DRAFT2"
+nonce: "install kip.token-policy-v1_DRAFT4"
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"

--- a/pact/yaml/testnet/token-policy-v1.yaml
+++ b/pact/yaml/testnet/token-policy-v1.yaml
@@ -4,7 +4,7 @@ signers:
 data:
   ns: "kip"
 networkId: testnet04
-nonce: "install kip.token-policy-v1_DRAFT4"
+nonce: "install kip.token-policy-v1"
 publicMeta:
   chainId: "0"
   sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"


### PR DESCRIPTION
- Rename interface `token-policy-v1_DRAFT4` to `token-policy-v1` , `poly-fungible-v2_DRAFT3` to `poly-fungible-v2`, and `account-protocols-v1_DRAFT1` to `account-protocols-v1`
- Upgrade `marmalade.ledger`, `util.fungible-util` and policy contracts to use the renamed interfaces 