### PR TITLE
Add event queries for given blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@testing-library/user-event": "^7.1.2",
     "clsx": "^1.1.1",
     "lowdash": "^1.2.0",
-    "pact-lang-api": "^4.1.2",
+    "pact-lang-api": "^4.3.2",
     "prop-types": "^15.7.2",
     "query-string": "^7.0.1",
     "react": "^16.13.1",

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from "react";
 import {
   Switch,
 } from 'react-router-dom';
-import { 
+import {
   useQueryParams,
   StringParam,
   withDefault
@@ -15,7 +15,7 @@ import {
   Container} from '@material-ui/core';
 import { NavDrawer } from "./NavDrawer.js";
 
-import { 
+import {
   walletDrawerEntries,
   WalletApp,
  } from "./PactWallet.js";
@@ -25,7 +25,7 @@ import {
   HftApp
 } from "./HFT/Hft.js";
 import { getHftState } from "./HFT/HftState.js";
-
+import { getSaleEvents, saleBlocks } from "./HFT/HftEvents.js"
 const App = () => {
   //Top level UI Routing Params
   const [appRoute,setAppRoute] = useQueryParams({
@@ -68,6 +68,7 @@ const App = () => {
   useEffect(() => {
     getHftLedger();
     getHftTokens();
+    getSaleEvents(saleBlocks)
     console.debug('App.useEffect[] fired');
   }, []);
 
@@ -86,7 +87,7 @@ const App = () => {
       setAppRoute={setAppRoute}
     />
     : appRoute.app === "hft" ?
-    <HftApp 
+    <HftApp
       appRoute={appRoute}
       setAppRoute={setAppRoute}
       hftLedger={hftLedger}

--- a/src/HFT/HftEvents.js
+++ b/src/HFT/HftEvents.js
@@ -1,0 +1,74 @@
+import React from "react";
+import _ from 'lodash';
+import ReactJson from 'react-json-view'
+//config file for blockchain calls
+import Pact from "pact-lang-api";
+import { hftAPI } from "../kadena-config.js";
+import { PactJsonListAsTable, dashStyleNames2Text } from "../util.js";
+
+export const saleBlocks = [1896893, 1896912];
+
+export const getHftEvents = async (blocks) => {
+  const hftEvents = await Promise.all(
+     blocks.map(b => {
+       return getHftBlockEvents(b);
+     })
+   );
+  console.log("HFT Events:", {"events": hftEvents.flat()})
+  return hftEvents;
+}
+
+export const getSaleEvents = async (blocks) => {
+  const saleEvents = await Promise.all(
+     blocks.map(b => {
+       return getSaleBlockEvents(b);
+     })
+   );
+  const flattenedEvents = saleEvents.flat();
+  const saleEventsInfo = flattenedEvents.map(e => saleEvent(e));
+  console.log("Sale Events:", {"rawEvents": flattenedEvents, "saleEvents": saleEventsInfo})
+  return flattenedEvents;
+}
+
+export const getSaleBlockEvents = async (block) => {
+  const events = await getBlockEvents(block);
+  return filterSaleEvent(events);
+};
+
+export const getHftBlockEvents = async (block) => {
+  const events = await getBlockEvents(block);
+  return filterHftEvent(events);
+};
+
+export const filterHftEvent = (events) => {
+    return filterEvents(events, hftAPI.namespace, hftAPI.contractName);
+};
+
+export const filterSaleEvent = (events) => {
+    return filterEvents(events, hftAPI.namespace, hftAPI.contractName, "SALE");
+};
+
+export const getBlockEvents = async (block) => {
+    const res = await Pact.event.height(hftAPI.meta.chainId, block, hftAPI.meta.networkId, hftAPI.meta.apiHost)
+    return(res);
+};
+
+export const filterEvents = (events, ns, mod, evName) => {
+  return events.filter(ev => {
+    if (ns && ns !== ev.module.namespace) return false;
+    if (mod && mod !== ev.module.name) return false;
+    if (evName && evName !== ev.name) return false;
+    else return true;
+  })
+};
+
+const saleEvent = (event) => {
+  return {
+    "eventName": `${event.module.namespace}.${event.module.name}.${event.name}`,
+    "token": event.params[0],
+    "seller": event.params[1],
+    "amount": event.params[2],
+    "timeout": event.params[3].int,
+    "sale-id": event.params[4]
+  }
+}

--- a/src/kadena-config.js
+++ b/src/kadena-config.js
@@ -48,8 +48,11 @@ const fqpConstants = {};
 //unique gas station contract name
 const gasStationName = "memory-wall-gas-station";
 
-//api host to send requests
+//pact api host to send requests
 const host = `https://${node}/chainweb/0.0/${networkId}/chain/${chainId}/pact`;
+
+//api host to send requests
+const apiHost = `https://${node}`;
 
 //creation time for request
 const creationTime = () => Math.round(new Date().getTime() / 1000) - 15;
@@ -109,6 +112,7 @@ const hftAPI = {
     networkId: networkId,
     chainId: chainId,
     host: host,
+    apiHost: apiHost,
     creationTime: creationTime,
     //gas price at lowest possible denomination
     gasPrice: 0.000000001,

--- a/src/kadena-config.js
+++ b/src/kadena-config.js
@@ -48,11 +48,12 @@ const fqpConstants = {};
 //unique gas station contract name
 const gasStationName = "memory-wall-gas-station";
 
+//chainweb api host
+const apiHost = `https://${node}`;
+
 //pact api host to send requests
 const host = `https://${node}/chainweb/0.0/${networkId}/chain/${chainId}/pact`;
 
-//api host to send requests
-const apiHost = `https://${node}`;
 
 //creation time for request
 const creationTime = () => Math.round(new Date().getTime() / 1000) - 15;


### PR DESCRIPTION
Added event query functions, that 
- queries events from specific block: `getBlockEvents`
- queries sale events from specific block: `getSaleBlockEvents`
- queries marmalade events from specific block: `getHftBlockEvents`
- queries sale events and parse sale info from list of blocks: `getSaleEvents`
- queries marmalade events from list of blocks: `getHftEvents`