### PR TITLE
Prevents double query to the `policies` table:

### DIFF
--- a/pact/fixed-quote-policy.pact
+++ b/pact/fixed-quote-policy.pact
@@ -55,7 +55,7 @@
       , 'min-amount:=min-amount:decimal
       , 'max-supply:=max-supply:decimal
       }
-      (enforce-guard (at 'mint-guard (get-policy token)))
+      (enforce-guard mint-guard)
       (enforce (>= min-amount 0.0) "Invalid min-amount")
       (enforce (<= (+ amount (at 'supply token)) max-supply) "Exceeds max supply")
   ))

--- a/pact/fixed-quote-royalty-policy.pact
+++ b/pact/fixed-quote-royalty-policy.pact
@@ -61,7 +61,7 @@
       , 'min-amount:=min-amount:decimal
       , 'max-supply:=max-supply:decimal
       }
-      (enforce-guard (at 'mint-guard (get-policy token)))
+      (enforce-guard mint-guard)
       (enforce (>= min-amount 0.0) "Invalid min-amount")
       (enforce (<= (+ amount (at 'supply token)) max-supply) "Exceeds max supply")
   ))


### PR DESCRIPTION
- Modifies `pact/fixed-quote-policy.pact` and `pact/fixed-quote-royalty-policy.pact` to avoid executing an additional `(get-policy token)` call in `enforce-mint`. Instead, uses the already assigned `mint-guard` variable from the `bind` call.