### PR TITLE
Add support for the bidding process in fungible-quote-policy

### DIFF
--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact
@@ -26,6 +26,7 @@
     @doc "Quote data to include in payload"
     fungible:module{fungible-v2}
     price:decimal
+    amount:decimal
     seller-guard:guard
   )
 

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact
@@ -45,4 +45,17 @@
     @doc "Get Quote information"
   )
 
+  (defun is-reserved:bool (sale-id:string)
+    @doc "Determine if a bid has been accepted"
+  )
+
+  (defun transfer-bid:bool (
+    buyer:string 
+    sale-id:string
+    escrow-account:string
+    escrow-guard:guard
+    sale-price:decimal)
+    @doc "Transfer of the bid amount from the bid-escrow account"       
+  )
+
 )

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact
@@ -26,8 +26,7 @@
     @doc "Quote data to include in payload"
     fungible:module{fungible-v2}
     price:decimal
-    recipient:string
-    recipient-guard:guard
+    seller-guard:guard
   )
 
   (defschema marketplace-fee-spec
@@ -38,7 +37,9 @@
 
   (defschema quote-schema
     id:string
-    spec:object{quote-spec})
+    spec:object{quote-spec}
+    reserved:string
+  )
 
   (defun get-quote:object{quote-schema} (sale-id:string)
     @doc "Get Quote information"

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.md
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.md
@@ -7,19 +7,34 @@ The `fungible-quote-policy-v1` is specifically tailored for managing token sales
   
 **Policy functions**: Several functions that enforce specific rules for token-related actions.
 
+**Bidding functions**: Several functions that support the bidding process  
+
 **Quote Specifications**: A schema for quote specifications, `quote-spec`, is provided, which includes details about the fungible token, price, recipient, and recipient guard.
 
 **Marketplace Fee Specifications**: A schema for marketplace fee specifications, `marketplace-fee-spec`, is included, with details about the marketplace account and fee.
 
 **Quote Table**: A table, `quotes`, is created to store the quote information, including the quote ID and its associated specifications.
 
-  
+**Bid Table**: A table, `bids`, is created to store the bid information
+
 
 ## Policy Functions
 
 `enforce-offer`: In order to facilitate the sale of tokens in a secure and controlled manner `enforce-offer` provides a mechanism to validate the essential details of a sale before initiating the sale process. The primary function of enforcing this rules is to make sure that the sale conditions are met, ultimately ensuring a safe and reliable marketplace for both buyers and sellers.
 
 `enforce-buy`: Enforces buying rules and handles the payment of marketplace fees and royalties, if applicable. The function also ensures that the correct sale token is used. In the end this ensures for buyers and sellers to trade their tokens are exchanged between the intended parties and transferred accordingly
+
+## Bid Functions
+
+`place-bid`: The place-bid function is responsible for placing a bid on a sale. It verifies that the bid is being placed on the correct sale token, transfers the specified amount from the buyer to an escrow account, stores the bid details in the bids collection, and emits a bid event.
+
+`withdraw-bid`: The withdraw-bid function is responsible for withdrawing a previously placed bid. It retrieves the bid details from the bids collection based on the provided bid-id. It verifies that the bid is in an open status and belongs to the buyer by checking the buyer's capability. It then transfers the bid amount from the bid's escrow account back to the buyer. Finally, it updates the bid status to "withdrawn" in the bids collection and emits a bid withdrawn event.
+
+`accept-bid`: The accept-bid function is responsible for accepting a bid for a sale. It retrieves the bid details from the bids collection based on the provided bid-id. It verifies that the bid is in an open status. It then retrieves the sale details from the quotes collection based on the provided sale-id. It updates the sale's spec by setting the fungible, price, seller-guard, and amount fields to match the bid. It also sets the buyer as reserved for the sale, so it can only be purchased by the buyer that placed the bid. The function can only be executed by the seller because it requires the capability of the seller's guard. It updates the bid status to "accepted" in the bids collection. Finally, it emits a bid accepted event.
+
+`transfer-bid`: The transfer-bid function facilitates the transfer of the bid amount to the escrow account that holds the funds for a specific sale before `enforce-buy` is executed in all attached policies. 
+
+Finally, the function returns true to indicate a successful transfer of the bid amount to the escrow account.
 
   
 ## Enabling
@@ -38,16 +53,16 @@ By utilising this policy module, you can build token sale platforms and marketpl
 #### QUOTE-MSG-KEY
 
   
-The `enforce-offer` function captures a quote specification for the sale of a fungible token from a message. The message payload contains the `quote-spec` based object within the `quote` property of the payload, which has three required fields: `fungible`, `price`, `recipient`, and `recipient-guard`.
+The `enforce-offer` function captures a quote specification for the sale of a fungible token from a message. The message payload contains the `quote-spec` based object within the `quote` property of the payload, which has four required fields: `fungible`, `price`, `amount`, and `seller-guard`.
 
 
-The `fungible` field specifies the module that contains the fungible token being sold. The `price` field specifies the price per unit of the token being sold. The `recipient` field specifies the recipient of the token being sold. The `recipient-guard` field specifies a guard that must be satisfied by the recipient's details.
+The `fungible` field specifies the module that contains the fungible token being sold. The `price` field specifies the price per unit of the token being sold. The `amount` field specifies the number of units that are being sold. The `seller-guard` field specifies the guard of the seller of the token.
 
 #### MARKETPLACE-FEE-MSG-KEY
   
-The `enforce-buy` function enables the purchase of a fungible token and enforces the transfer of funds from the buyer to the seller and marketplace fees, if applicable. The message payload contains the `marketplace-fee-spec` object within the `marketplace-fee` property of the payload, which has two required fields: `marketplace-account` and `fee`.
+The `enforce-buy` function enables the purchase of a fungible token and enforces the transfer of funds from the buyer to the seller and marketplace fees, if applicable. The message payload contains the `marketplace-fee-spec` object within the `marketplace-fee` property of the payload, which has two required fields: `marketplace-account` and `mk-fee-percentage`.
     
-The `marketplace-account` field specifies the account to which the marketplace fees will be transferred. The `fee` field specifies the percentage of the sale price that will be charged as a fee.
+The `marketplace-account` field specifies the account to which the marketplace fees will be transferred. The `mk-fee-percentage` field specifies the percentage of the sale price that will be charged as a fee.
 
 Once the `marketplace-fee-spec` object has been read from the message payload, the function extracts the relevant fields from it and performs several checks to ensure the validity of the sale. It then transfers the appropriate funds to the seller, as well as any applicable marketplace fees.
 
@@ -63,3 +78,41 @@ This event is emitted using the following line of code:
 ```(emit-event (QUOTE sale-id (at 'id token) amount price sale-price spec))```
 
 
+#### BID Event
+The `BID` event is emitted when a bid is placed in the `place-bid` function. It represents the act of placing a bid on a sale. 
+
+The event contains the following information:
+- `bid-id`: The unique identifier of the placed bid.
+- `sale-id`: The identifier of the sale for which the bid is placed.
+- `token-id`: The identifier of the token associated with the bid.
+- `amount`: The amount of tokens that the bid is for (this must match the amount of tokens that are on offer).
+- `price`: The price for a single token at which the bid is placed.
+- `buyer`: The account of the buyer who placed the bid.
+
+The `BID` event serves as a notification for interested parties that a new bid has been placed, and it provides relevant details about the bid and the sale.
+
+#### BID-WITHDRAWN Event
+The `BID-WITHDRAWN` event is emitted when a bid is withdrawn in the `withdraw-bid` function. It represents the action of removing a previously placed bid from consideration.
+
+The event contains the following information:
+- `bid-id`: The unique identifier of the withdrawn bid.
+- `sale-id`: The identifier of the sale from which the bid is withdrawn.
+- `token-id`: The identifier of the token associated with the bid.
+- `amount`: The amount of tokens that the bid was for (this must match the amount of tokens that are on offer).
+- `price`: The price for a single token at which the bid was placed.
+- `buyer`: The identity of the buyer who withdrew the bid.
+
+The `BID-WITHDRAWN` event serves as a notification for interested parties that a bid has been withdrawn. It provides relevant details about the withdrawn bid, including the associated sale and the buyer who withdrew the bid.
+
+#### BID-ACCEPTED Event
+The `BID-ACCEPTED` event is emitted when a bid is accepted in the `accept-bid` function. It signifies that a bid has been successfully accepted by the seller. 
+
+The event contains the following information:
+- `bid-id`: The unique identifier of the accepted bid.
+- `sale-id`: The identifier of the sale for which the bid was accepted.
+- `token-id`: The identifier of the token associated with the bid.
+- `amount`: The amount of tokens that the bid is for (this must match the amount of tokens that are on offer).
+- `price`: The price for a single token at which the bid is placed.
+- `buyer`: The account of the buyer who placed the bid.
+
+The `BID-ACCEPTED` event serves as a notification for interested parties that a specific bid has been accepted and provides relevant details about the bid and the sale.

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.pact
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.pact
@@ -178,7 +178,7 @@
         }
 
       (let* (
-        (mk-fee-spec:object{marketplace-fee-spec} (read-msg MARKETPLACE-FEE-MSG-KEY))
+        (mk-fee-spec:object{marketplace-fee-spec} (try { "marketplace-account": "", "mk-fee-percentage": 0.0 } (read-msg MARKETPLACE-FEE-MSG-KEY)))
         (mk-account:string (at 'marketplace-account mk-fee-spec))
         (mk-fee-percentage:decimal (at 'mk-fee-percentage mk-fee-spec))
         (mk-fee:decimal (floor (* mk-fee-percentage price) (fungible::precision)))

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
@@ -247,3 +247,82 @@
     (coin.get-balance "marketplace"))
 
 (rollback-tx)
+
+(begin-tx "Sell token and place multiple bids")
+
+  (env-hash (hash "offer-bidding-1"))
+  (use marmalade.ledger)
+
+  (test-capability (coin.COINBASE))
+  (env-data {
+    "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
+  })
+  (coin.coinbase "account" (read-keyset 'seller-guard) 2.0)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+  ,"quote": {
+    "fungible": coin
+    ,"price": 10.0
+    ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
+    })
+
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+    (marmalade.ledger.OFFER (read-msg 'token-id ) "account" 1.0 (time "2023-07-22T11:26:35Z") )]
+    }])
+
+  (expect "Start offer succeeds"
+    true
+    (sale (read-msg 'token-id) 'account 1.0 (time "2023-07-22T11:26:35Z")))
+
+  ; (expect "events"
+  ;   (format "{}" [[   {"name": "coin.TRANSFER","params": ["" "account" 2.0]}
+  ;     {"name": "marmalade.ledger.OFFER","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" 1.0 "2023-07-22T11:26:35Z"]}
+  ;     {"name": "marmalade.ledger.SALE","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+  ;     {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 2.0 2.0 {"fungible": coin,"price": 2.0,"seller-guard": ""}]}
+  ;     {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
+  ;     {"name": "marmalade.ledger.TRANSFER","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
+  ;     {"name": "marmalade.ledger.RECONCILE","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 {"account": "account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
+  ;   (format "{}" [(map (remove "module-hash")  (env-events true))])
+  ; )(rollback-tx)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+    ,"sale-id": "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8"
+    ,"bidder": "bidder"
+    ,"bidder-guard": {"keys": ["bidder"], "pred": "keys-all"}
+  })
+
+  (test-capability (coin.COINBASE))
+  (coin.coinbase "bidder-account" (read-keyset 'bidder-guard) 25.0)
+
+  (env-sigs
+  [{'key:'bidder
+    ,'caps: [
+      ; (BUY (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } ) "account" "buyer-account"  1.0 (time  "2023-07-22T11:26:35Z") "v86vqj0OkIZQfD3XGETjij1sLjJH7Q6GZBZJeytDsEo")
+      (coin.TRANSFER "bidder-account" "c:cbnfX-2IcN_in1gOZpdheAlkbERuqFIUNOYE8egBx38" 5.0)
+    ]}])
+  ;
+  ; (env-hash (hash "offer-royalty-0"))
+
+  (expect "Place Bid succeeds"
+    true
+    (marmalade.fungible-quote-policy-v1.place-bid (read-msg 'token-id) 'bidder (read-keyset 'bidder-guard) 1.0 5.0 (read-msg 'sale-id))
+  )
+
+  ; (expect "Buyer account has 0.0 tokens left"
+  ;   0.0
+  ;   (coin.get-balance "buyer-account"))
+  ;
+  ; (expect "Seller account has 4.0 tokens"
+  ;   4.0
+  ;   (coin.get-balance "account"))
+  ;
+  ; (expect "Marketplace fee account has 2.0 tokens"
+  ;   2.0
+  ;   (coin.get-balance "marketplace"))
+
+(rollback-tx)

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
@@ -94,8 +94,7 @@
   , "quote": {
       "fungible": coin
       ,"price": 2.0
-      ,"recipient": 'seller-account
-      ,"recipient-guard": {"keys": ["seller"], "pred": "keys-all"}}
+      ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
     })
 
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
@@ -120,15 +119,14 @@
   (env-data {
     "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
   })
-  (coin.coinbase "seller-account" (read-keyset 'seller-guard) 2.0)
+  (coin.coinbase "account" (read-keyset 'seller-guard) 2.0)
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
   ,"quote": {
     "fungible": coin
     ,"price": 2.0
-    ,"recipient": 'seller-account
-    ,"recipient-guard": {"keys": ["seller"], "pred": "keys-all"}}
+    ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
     })
 
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
@@ -174,7 +172,7 @@
 
   (expect "Seller account has 3.9 tokens"
     3.9
-    (coin.get-balance "seller-account"))
+    (coin.get-balance "account"))
 
   (expect "Marketplace fee account has 2.1 tokens"
     2.1
@@ -191,15 +189,14 @@
   (env-data {
     "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
   })
-  (coin.coinbase "seller-account" (read-keyset 'seller-guard) 2.0)
+  (coin.coinbase "account" (read-keyset 'seller-guard) 2.0)
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
   ,"quote": {
     "fungible": coin
     ,"price": 2.0
-    ,"recipient": 'seller-account
-    ,"recipient-guard": {"keys": ["seller"], "pred": "keys-all"}}
+    ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
     })
 
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
@@ -243,7 +240,7 @@
 
   (expect "Seller account has 4.0 tokens"
     4.0
-    (coin.get-balance "seller-account"))
+    (coin.get-balance "account"))
 
   (expect "Marketplace fee account has 2.0 tokens"
     2.0

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
@@ -94,6 +94,7 @@
   , "quote": {
       "fungible": coin
       ,"price": 2.0
+      ,"amount": 1.0
       ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
     })
 
@@ -126,6 +127,7 @@
   ,"quote": {
     "fungible": coin
     ,"price": 2.0
+    ,"amount": 1.0
     ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
     })
 
@@ -196,6 +198,7 @@
   ,"quote": {
     "fungible": coin
     ,"price": 2.0
+    ,"amount": 1.0
     ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
     })
 
@@ -245,10 +248,9 @@
   (expect "Marketplace fee account has 2.0 tokens"
     2.0
     (coin.get-balance "marketplace"))
-
 (rollback-tx)
 
-(begin-tx "Sell token and place multiple bids")
+(begin-tx "Sell token and place bid")
 
   (env-hash (hash "offer-bidding-1"))
   (use marmalade.ledger)
@@ -264,6 +266,7 @@
   ,"quote": {
     "fungible": coin
     ,"price": 10.0
+    ,"amount": 1.0
     ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
     })
 
@@ -271,28 +274,16 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-    (marmalade.ledger.OFFER (read-msg 'token-id ) "account" 1.0 (time "2023-07-22T11:26:35Z") )]
+    (marmalade.ledger.OFFER (read-msg 'token-id) "account" 1.0 (time "2023-07-22T11:26:35Z") )]
     }])
 
   (expect "Start offer succeeds"
     true
     (sale (read-msg 'token-id) 'account 1.0 (time "2023-07-22T11:26:35Z")))
 
-  ; (expect "events"
-  ;   (format "{}" [[   {"name": "coin.TRANSFER","params": ["" "account" 2.0]}
-  ;     {"name": "marmalade.ledger.OFFER","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" 1.0 "2023-07-22T11:26:35Z"]}
-  ;     {"name": "marmalade.ledger.SALE","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-  ;     {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 2.0 2.0 {"fungible": coin,"price": 2.0,"seller-guard": ""}]}
-  ;     {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
-  ;     {"name": "marmalade.ledger.TRANSFER","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
-  ;     {"name": "marmalade.ledger.RECONCILE","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 {"account": "account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
-  ;   (format "{}" [(map (remove "module-hash")  (env-events true))])
-  ; )(rollback-tx)
-
   (env-data {
     "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
     ,"sale-id": "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8"
-    ,"bidder": "bidder"
     ,"bidder-guard": {"keys": ["bidder"], "pred": "keys-all"}
   })
 
@@ -302,27 +293,89 @@
   (env-sigs
   [{'key:'bidder
     ,'caps: [
-      ; (BUY (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } ) "account" "buyer-account"  1.0 (time  "2023-07-22T11:26:35Z") "v86vqj0OkIZQfD3XGETjij1sLjJH7Q6GZBZJeytDsEo")
-      (coin.TRANSFER "bidder-account" "c:cbnfX-2IcN_in1gOZpdheAlkbERuqFIUNOYE8egBx38" 5.0)
+       (coin.TRANSFER "bidder-account" "c:fsTjb6w6jogvXcyIEhzFaOv-G5f_R6bOWeDR16ON0kM" 5.0)
     ]}])
-  ;
-  ; (env-hash (hash "offer-royalty-0"))
 
   (expect "Place Bid succeeds"
     true
-    (marmalade.fungible-quote-policy-v1.place-bid (read-msg 'token-id) 'bidder (read-keyset 'bidder-guard) 1.0 5.0 (read-msg 'sale-id))
+    (marmalade.fungible-quote-policy-v1.place-bid (read-msg 'token-id) 'bidder-account (read-keyset 'bidder-guard) 1.0 5.0 (read-msg 'sale-id))
   )
 
-  ; (expect "Buyer account has 0.0 tokens left"
-  ;   0.0
-  ;   (coin.get-balance "buyer-account"))
-  ;
-  ; (expect "Seller account has 4.0 tokens"
-  ;   4.0
-  ;   (coin.get-balance "account"))
-  ;
-  ; (expect "Marketplace fee account has 2.0 tokens"
-  ;   2.0
-  ;   (coin.get-balance "marketplace"))
+  (expect "Buyer account has 20.0 tokens left"
+    20.0
+    (coin.get-balance "bidder-account"))
+(commit-tx)
 
+(begin-tx "Withdraw bid")
+
+  (env-hash (hash "withdraw-bidding-1"))
+  (use marmalade.fungible-quote-policy-v1)
+
+  (env-data {
+    "bid-id": (get-bid-id "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8" "bidder-account")
+    ,"sale-id": "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8"
+    ,"bidder-guard": {"keys": ["bidder"], "pred": "keys-all"}
+  })
+
+  (env-sigs
+  [{'key:'bidder
+    ,'caps: [
+      (BUYER (read-keyset 'bidder-guard))
+    ]}])
+
+  (expect "Withdraw Bid succeeds"
+    true
+    (withdraw-bid (read-msg 'bid-id) (read-msg 'sale-id))
+  )
+
+  (expect "Buyer account has 25.0 tokens"
+    25.0
+    (coin.get-balance "bidder-account"))
 (rollback-tx)
+
+(begin-tx "Accept bid and finish sale")
+
+  (env-hash (hash "accept-bidding-1"))
+  (use marmalade.fungible-quote-policy-v1)
+
+  (env-data {
+    "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
+    ,"bid-id": (get-bid-id "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8" "bidder-account")
+    ,"sale-id": "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8"
+  })
+
+  (env-sigs [
+    { 'key: 'seller
+    ,'caps: [
+      (SELLER (read-msg 'seller-guard))
+    ]
+    }])
+
+  (expect "Accept-bid succeeds"
+    true
+    (accept-bid (read-msg 'bid-id) (read-msg 'sale-id)))
+
+  (env-data {
+    "buyer": "bidder-account"
+    ,"buyer-guard": {"keys": ["bidder"], "pred": "keys-all"}
+    ,"market-guard": {"keys": ["market"], "pred": "keys-all"}
+    ,"marketplace-fee": {
+    "marketplace-account":""
+    ,"mk-fee-percentage": 0.0
+  }})
+
+  (env-sigs [
+    { 'key: 'bidder
+    ,'caps: [
+      (marmalade.ledger.BUY (marmalade.ledger.create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } ) "account" "bidder-account"  1.0 (time  "2023-07-22T11:26:35Z") "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8")
+      ]
+    }])
+
+  (expect "Buy succeeds"
+      true
+      (continue-pact 1 false "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8"))
+
+  (expect "Seller account has increased with 5 tokens"
+    7.0
+    (coin.get-balance "account"))
+(commit-tx)

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
@@ -320,7 +320,7 @@
   (env-sigs
   [{'key:'bidder
     ,'caps: [
-      (BUYER (read-keyset 'bidder-guard))
+      (BUYER (read-msg 'bid-id))
     ]}])
 
   (expect "Withdraw Bid succeeds"
@@ -347,7 +347,7 @@
   (env-sigs [
     { 'key: 'seller
     ,'caps: [
-      (SELLER (read-msg 'seller-guard))
+      (SELLER (read-msg 'sale-id))
     ]
     }])
 

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -111,8 +111,8 @@
  ,"quote": {
    "fungible": coin
   ,"price": 2.0
-  ,"recipient": 'seller-account
-  ,"recipient-guard": {"keys": ["seller"], "pred": "keys-all"}}
+  ,"amount": 1.0
+  ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
   })
 
 (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -121,6 +121,7 @@
  ,"quote": {
    "fungible": coin
   ,"price": 2.0
+  ,"amount": 1.0
   ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
   })
 
@@ -140,7 +141,7 @@
   (format "{}" [[   {"name": "coin.TRANSFER","params": ["" "account" 2.0]}
     {"name": "marmalade.ledger.OFFER","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" 1.0 "2023-07-22T11:26:35Z"]}
     {"name": "marmalade.ledger.SALE","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-    {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 2.0 2.0 {"fungible": coin,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
+    {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 2.0 2.0 {"amount": 1.0,"fungible": coin,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
     {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
     {"name": "marmalade.ledger.TRANSFER","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
     {"name": "marmalade.ledger.RECONCILE","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 {"account": "account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -74,7 +74,7 @@
 (load "../policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact")
 (load "../policies/guard-policy/guard-policy-v1.pact")
 (load "../policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact")
-(load "../policies/migration-policy/migration-policy-v1.pact")
+;  (load "../policies/migration-policy/migration-policy-v1.pact")
 
 (commit-tx)
 
@@ -114,15 +114,14 @@
 (env-data {
   "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
 })
-(coin.coinbase "seller-account" (read-keyset 'seller-guard) 2.0)
+(coin.coinbase "account" (read-keyset 'seller-guard) 2.0)
 
 (env-data {
   "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-default-policies DEFAULT) } )
  ,"quote": {
    "fungible": coin
   ,"price": 2.0
-  ,"recipient": 'seller-account
-  ,"recipient-guard": {"keys": ["seller"], "pred": "keys-all"}}
+  ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
   })
 
 (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
@@ -135,13 +134,13 @@
   true
   (sale (read-msg 'token-id) 'account 1.0 (time "2023-07-22T11:26:35Z")))
 
-(env-data { "recipient-guard": {"keys": ["seller"], "pred": "keys-all"}})
+(env-data { "seller-guard": {"keys": ["seller"], "pred": "keys-all"}})
 
 (expect "events"
-  (format "{}" [[   {"name": "coin.TRANSFER","params": ["" "seller-account" 2.0]}
+  (format "{}" [[   {"name": "coin.TRANSFER","params": ["" "account" 2.0]}
     {"name": "marmalade.ledger.OFFER","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" 1.0 "2023-07-22T11:26:35Z"]}
     {"name": "marmalade.ledger.SALE","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-    {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 2.0 2.0 {"fungible": coin,"price": 2.0,"recipient": "seller-account","recipient-guard": (read-keyset 'recipient-guard )}]}
+    {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 2.0 2.0 {"fungible": coin,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
     {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
     {"name": "marmalade.ledger.TRANSFER","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" "account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
     {"name": "marmalade.ledger.RECONCILE","params": ["t:u5kvgh1HISROlQGLTQGF7gTzyjBtXxSe7BQjI3cPcC8" 1.0 {"account": "account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])


### PR DESCRIPTION

Support for a basic bidding process in the funqible quote policy which enables the follow actions:
- Placing a bid on a token that is offered for sale, bid amount will be held in escrow
- Withdrawing a bid by the bidder
- Accepting a bid on a token by the seller
