### PR TITLE
Remove ledger.rotate

### DIFF
--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -221,19 +221,6 @@
       " Get details of ACCOUNT under ID. Fails if account does not exist."
   )
 
-  (defun rotate:bool
-    ( id:string
-      account:string
-      new-guard:guard )
-    @doc
-      " Rotate guard for ACCOUNT for ID to NEW-GUARD, validating against existing guard."
-    @model
-      [ (property (!= id ""))
-        (property (!= account ""))
-      ]
-
-  )
-
   (defun transfer:bool
     ( id:string
       sender:string

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -139,11 +139,6 @@
   ;; Implementation caps
   ;;
 
-  (defcap ROTATE (id:string account:string)
-    @doc "Autonomously managed capability for guard rotation"
-    @managed
-    true)
-
   (defcap DEBIT (id:string sender:string)
     (enforce-guard (account-guard id sender))
   )
@@ -280,18 +275,7 @@
     ( id:string account:string )
     (read ledger (key id account))
   )
-
-  (defun rotate:bool (id:string account:string new-guard:guard)
-    (with-capability (ROTATE id account)
-      (enforce-transfer-policy id account account 0.0)
-      (with-read ledger (key id account)
-        { "guard" := old-guard }
-
-        (enforce-guard old-guard)
-        (update ledger (key id account)
-          { "guard" : new-guard })
-        (emit-event (ACCOUNT_GUARD id account new-guard)))))
-
+  
   (defun transfer:bool
     ( id:string
       sender:string

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -85,23 +85,33 @@
 (use marmalade.util-v1)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-default-policies DEFAULT) } )
+  "default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-default-policies DEFAULT) } )
+ ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-default-policies EMPTY) } )
  ,"account": "account"
- ,"nfp-mint-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
   })
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade.ledger.MINT "t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "account" 1.0)]
+   ,'caps: [(marmalade.ledger.MINT "t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "account" 1.0)
+            (marmalade.ledger.MINT "t:6ll2WfFkYk7Pi6oZiFlpRLC7VadDLg50f9Ref4oA54Y" "account" 1.0)
+   ]
    }])
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'token-id) 0 "test-uri" (create-default-policies DEFAULT) ))
+  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-default-policies DEFAULT) ))
+
+(expect "create a token with no concrete-policy"
+  true
+  (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-default-policies EMPTY) ))
 
 (expect "mint a default token with quote-policy, non-fungible-policy"
   true
-  (mint (read-msg 'token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))
+  (mint (read-msg 'default-token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))
+
+(expect "mint an empty token with no policy"
+  true
+  (mint (read-msg 'empty-token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))
 
 (commit-tx)
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -27,7 +27,7 @@
 
 
   (define-namespace 'util (sig-keyset) (sig-keyset))
-  (load "../util/fungible-util.pact")  
+  (load "../util/fungible-util.pact")
 (commit-tx)
 
 (begin-tx)
@@ -116,38 +116,6 @@
   (mint (read-msg 'empty-token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))
 
 (commit-tx)
-
-(begin-tx "Try rotate")
-
-  (use marmalade.ledger)
-  (use marmalade.policy-manager)
-  (use marmalade.util-v1)
-
-  (env-data {
-    "default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-default-policies DEFAULT) } )
-   ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-default-policies EMPTY) } )
-   ,"account": "account"
-   ,"new-guard": {"keys": ["rotate"], "pred": "keys-all"}
-    })
-  (env-sigs [
-    { 'key: 'account
-     ,'caps: [(marmalade.ledger.ROTATE "t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "account")
-              (marmalade.ledger.ROTATE "t:6ll2WfFkYk7Pi6oZiFlpRLC7VadDLg50f9Ref4oA54Y" "account")]
-     }])
-
-  (expect "t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4 `fungible-quote-policy-v1` allows transfer"
-    true
-    (rotate (read-msg 'default-token-id) 'account (read-keyset 'new-guard ) ))
-
-  (expect "t:6ll2WfFkYk7Pi6oZiFlpRLC7VadDLg50f9Ref4oA54Y Rotate succeeds"
-    true
-    (rotate (read-msg 'empty-token-id) 'account (read-keyset 'new-guard ) ))
-
-  (expect "Account guard of the empty token matches the new guard"
-    (read-keyset 'new-guard )
-    (account-guard (read-msg 'empty-token-id ) 'account ))
-
-(rollback-tx)
 
 (begin-tx "start an offer")
   (env-hash (hash "offer-0"))


### PR DESCRIPTION
To comply with [KIP-0019](https://github.com/kadena-io/KIPs/pull/43) account standards, `ledger.rotate` function is removed