### PR TITLE
Omitting coin contract from tests

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -26,11 +26,10 @@
 (begin-tx)
   (use marmalade.ledger)
   (use marmalade.policy-manager)
-  (test-capability (coin.COINBASE))
   (env-data {
     "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
   })
-  (coin.coinbase "creator-account" (read-keyset 'creator-guard) 2.0)
+  (marmalade.abc.create-account "creator-account" (read-keyset 'creator-guard))
 (commit-tx)
 
 (begin-tx "Creating collection")
@@ -41,7 +40,7 @@
   ,"account": "account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
-      "fungible": coin
+      "fungible": marmalade.abc
     ,"creator": 'creator-account
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05
@@ -124,7 +123,7 @@
   ,"account": "account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
-      "fungible": coin
+      "fungible": marmalade.abc
     ,"creator": 'creator-account
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05
@@ -160,7 +159,7 @@
   ,"account": "account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
-      "fungible": coin
+      "fungible": marmalade.abc
     ,"creator": 'creator-account
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
@@ -95,16 +95,14 @@
   (env-hash (hash "offer-quote-only-0"))
   (use marmalade.ledger)
 
-  (test-capability (coin.COINBASE))
   (env-data {
     "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
   })
-  (coin.coinbase "seller-account" (read-keyset 'seller-guard) 2.0)
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
   , "quote": {
-      "fungible": coin
+      "fungible": marmalade.abc
       ,"price": 2.0
       ,"amount": 1.0
       ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
@@ -128,16 +126,16 @@
   (env-hash (hash "offer-quote-only-1"))
   (use marmalade.ledger)
 
-  (test-capability (coin.COINBASE))
   (env-data {
     "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
   })
-  (coin.coinbase "account" (read-keyset 'seller-guard) 2.0)
+  (marmalade.abc.create-account "account" (read-keyset 'seller-guard))
+  (marmalade.abc.fund "account" 2.0)
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
   ,"quote": {
-    "fungible": coin
+    "fungible": marmalade.abc
     ,"price": 2.0
     ,"amount": 1.0
     ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
@@ -163,15 +161,15 @@
     ,"mk-fee-percentage": 0.05
     }})
 
-  (test-capability (coin.COINBASE))
-  (coin.coinbase "buyer-account" (read-keyset 'buyer-guard) 2.0)
-  (coin.coinbase "marketplace" (read-keyset 'buyer-guard) 2.0)
+  (marmalade.abc.create-account "buyer-account" (read-keyset 'buyer-guard))
+  (marmalade.abc.create-account "marketplace" (read-keyset 'market-guard))
+  (marmalade.abc.fund "buyer-account" 2.0)
 
   (env-sigs
   [{'key:'buyer
     ,'caps: [
       (BUY (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } ) "account" "buyer-account"  1.0 (time  "2023-07-22T11:26:35Z") "v86vqj0OkIZQfD3XGETjij1sLjJH7Q6GZBZJeytDsEo")
-      (coin.TRANSFER "buyer-account" "c:cbnfX-2IcN_in1gOZpdheAlkbERuqFIUNOYE8egBx38" 2.0)
+      (marmalade.abc.TRANSFER "buyer-account" "c:cbnfX-2IcN_in1gOZpdheAlkbERuqFIUNOYE8egBx38" 2.0)
     ]}])
 
   (env-hash (hash "offer-royalty-0"))
@@ -182,15 +180,15 @@
 
   (expect "Buyer account has 0.0 tokens left"
     0.0
-    (coin.get-balance "buyer-account"))
+    (marmalade.abc.get-balance "buyer-account"))
 
   (expect "Seller account has 3.9 tokens"
     3.9
-    (coin.get-balance "account"))
+    (marmalade.abc.get-balance "account"))
 
   (expect "Marketplace fee account has 2.1 tokens"
-    2.1
-    (coin.get-balance "marketplace"))
+    0.1
+    (marmalade.abc.get-balance "marketplace"))
 
 (rollback-tx)
 
@@ -199,16 +197,15 @@
   (env-hash (hash "offer-quote-only-1"))
   (use marmalade.ledger)
 
-  (test-capability (coin.COINBASE))
   (env-data {
     "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
   })
-  (coin.coinbase "account" (read-keyset 'seller-guard) 2.0)
+  (marmalade.abc.create-account "account" (read-keyset 'seller-guard))
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
   ,"quote": {
-    "fungible": coin
+    "fungible": marmalade.abc
     ,"price": 2.0
     ,"amount": 1.0
     ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
@@ -232,15 +229,15 @@
   ,"marketplace-fee": {"marketplace-account": "", "mk-fee-percentage": 0.0 }
   })
 
-  (test-capability (coin.COINBASE))
-  (coin.coinbase "buyer-account" (read-keyset 'buyer-guard) 2.0)
-  (coin.coinbase "marketplace" (read-keyset 'buyer-guard) 2.0)
+  (marmalade.abc.create-account "buyer-account" (read-keyset 'buyer-guard))
+  (marmalade.abc.create-account "marketplace" (read-keyset 'market-guard))
+  (marmalade.abc.fund "buyer-account" 2.0)
 
   (env-sigs
   [{'key:'buyer
     ,'caps: [
       (BUY (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } ) "account" "buyer-account"  1.0 (time  "2023-07-22T11:26:35Z") "v86vqj0OkIZQfD3XGETjij1sLjJH7Q6GZBZJeytDsEo")
-      (coin.TRANSFER "buyer-account" "c:cbnfX-2IcN_in1gOZpdheAlkbERuqFIUNOYE8egBx38" 2.0)
+      (marmalade.abc.TRANSFER "buyer-account" "c:cbnfX-2IcN_in1gOZpdheAlkbERuqFIUNOYE8egBx38" 2.0)
     ]}])
 
   (env-hash (hash "offer-royalty-0"))
@@ -251,15 +248,15 @@
 
   (expect "Buyer account has 0.0 tokens left"
     0.0
-    (coin.get-balance "buyer-account"))
+    (marmalade.abc.get-balance "buyer-account"))
 
-  (expect "Seller account has 4.0 tokens"
-    4.0
-    (coin.get-balance "account"))
-
-  (expect "Marketplace fee account has 2.0 tokens"
+  (expect "Seller account has 2.0 tokens"
     2.0
-    (coin.get-balance "marketplace"))
+    (marmalade.abc.get-balance "account"))
+
+  (expect "Marketplace fee account has 0 tokens"
+    0.0
+    (marmalade.abc.get-balance "marketplace"))
 (rollback-tx)
 
 (begin-tx "Sell token and place bid")
@@ -267,16 +264,15 @@
   (env-hash (hash "offer-bidding-1"))
   (use marmalade.ledger)
 
-  (test-capability (coin.COINBASE))
   (env-data {
     "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
   })
-  (coin.coinbase "account" (read-keyset 'seller-guard) 2.0)
+  (marmalade.abc.create-account "account" (read-keyset 'seller-guard))
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
   ,"quote": {
-    "fungible": coin
+    "fungible": marmalade.abc
     ,"price": 10.0
     ,"amount": 1.0
     ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
@@ -299,13 +295,13 @@
     ,"bidder-guard": {"keys": ["bidder"], "pred": "keys-all"}
   })
 
-  (test-capability (coin.COINBASE))
-  (coin.coinbase "bidder-account" (read-keyset 'bidder-guard) 25.0)
+  (marmalade.abc.create-account "bidder-account" (read-keyset 'bidder-guard))
+  (marmalade.abc.fund "bidder-account" 25.0)
 
   (env-sigs
   [{'key:'bidder
     ,'caps: [
-       (coin.TRANSFER "bidder-account" "c:fsTjb6w6jogvXcyIEhzFaOv-G5f_R6bOWeDR16ON0kM" 5.0)
+       (marmalade.abc.TRANSFER "bidder-account" "c:fsTjb6w6jogvXcyIEhzFaOv-G5f_R6bOWeDR16ON0kM" 5.0)
     ]}])
 
   (expect "Place Bid succeeds"
@@ -315,7 +311,7 @@
 
   (expect "Buyer account has 20.0 tokens left"
     20.0
-    (coin.get-balance "bidder-account"))
+    (marmalade.abc.get-balance "bidder-account"))
 (commit-tx)
 
 (begin-tx "Withdraw bid")
@@ -342,7 +338,7 @@
 
   (expect "Buyer account has 25.0 tokens"
     25.0
-    (coin.get-balance "bidder-account"))
+    (marmalade.abc.get-balance "bidder-account"))
 (rollback-tx)
 
 (begin-tx "Accept bid and finish sale")
@@ -388,6 +384,6 @@
       (continue-pact 1 false "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8"))
 
   (expect "Seller account has increased with 5 tokens"
-    7.0
-    (coin.get-balance "account"))
+    5.0
+    (marmalade.abc.get-balance "account"))
 (commit-tx)

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -16,8 +16,6 @@
     }
   )
 
-
-
   (defconst DEFAULT_POLICIES_WITH_GUARD:object{token-policies}
     { 'concrete-policies:DEFAULT
      ,'immutable-policies: []
@@ -30,7 +28,6 @@
 (begin-tx)
   (use marmalade.ledger)
   (use marmalade.policy-manager)
-  (test-capability (coin.COINBASE))
 (commit-tx)
 
 (begin-tx "Create token without mint guard")

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -26,11 +26,10 @@
 (begin-tx)
   (use marmalade.ledger)
   (use marmalade.policy-manager)
-  (test-capability (coin.COINBASE))
   (env-data {
     "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
   })
-  (coin.coinbase "creator-account" (read-keyset "creator-guard") 2.0)
+  (marmalade.abc.create-account "creator-account" (read-keyset 'creator-guard))
 (commit-tx)
 
 (begin-tx)

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -124,7 +124,7 @@
         (enforce (= (at 'id quote) (at 'id token)) "incorrect sale token")
         (if
           (> royalty-payout 0.0)
-          [ (install-capability (coin.TRANSFER escrow-account creator royalty-payout))
+          [ (install-capability (fungible::TRANSFER escrow-account creator royalty-payout))
             (emit-event (ROYALTY sale-id (at 'id token) royalty-payout creator))
             (fungible::transfer escrow-account creator royalty-payout)
           ]

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -26,11 +26,10 @@
 (begin-tx)
 (use marmalade.ledger)
 (use marmalade.policy-manager)
-(test-capability (coin.COINBASE))
 (env-data {
   "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
 })
-(coin.coinbase "creator-account" (read-keyset 'creator-guard) 2.0)
+(marmalade.abc.create-account "creator-account" (read-keyset 'creator-guard))
 (commit-tx)
 (begin-tx)
 (use marmalade.ledger)
@@ -67,7 +66,7 @@
  ,"account": "account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
-    "fungible": coin
+    "fungible": marmalade.abc
    ,"creator": 'creator-account
    ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty-rate": 0.05
@@ -93,16 +92,15 @@
 (env-hash (hash "offer-royalty-0"))
 (use marmalade.ledger)
 
-(test-capability (coin.COINBASE))
 (env-data {
   "seller-guard": {"keys": ["seller"], "pred": "keys-all"}
 })
-(coin.coinbase "account" (read-keyset 'seller-guard) 2.0)
+(marmalade.abc.create-account "account" (read-keyset 'seller-guard))
 
 (env-data {
   "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: util.DEFAULT_POLICIES_WITH_ROYALTY } )
  ,"quote": {
-   "fungible": coin
+   "fungible": marmalade.abc
   ,"price": 2.0
   ,"amount": 1.0
   ,"seller-guard": {"keys": ["seller"], "pred": "keys-all"}}
@@ -121,10 +119,6 @@
 
 (env-data { "recipient-guard": {"keys": ["seller"], "pred": "keys-all"}})
 
-; (expect "events"
-;   []
-;   (map (remove 'module-hash)  (env-events true)))
-
 (env-data {
   "buyer": "buyer-account"
  ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
@@ -133,15 +127,16 @@
    "marketplace-account":"marketplace"
   ,"mk-fee-percentage": 0.05
   }})
-(test-capability (coin.COINBASE))
-(coin.coinbase "buyer-account" (read-keyset 'buyer-guard) 2.0)
-(coin.coinbase "marketplace" (read-keyset 'market-guard) 1.0)
+
+(marmalade.abc.create-account "buyer-account" (read-keyset 'buyer-guard))
+(marmalade.abc.create-account "marketplace" (read-keyset 'market-guard))
+(marmalade.abc.fund "buyer-account" 2.0)
 
 (env-sigs
  [{'key:'buyer
   ,'caps: [
     (BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: util.DEFAULT_POLICIES_WITH_ROYALTY } ) "account" "buyer-account"  1.0 (time  "2023-07-22T11:26:35Z") "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
-    (coin.TRANSFER "buyer-account" "c:z85Gnsq2GGFlAPL4lmU1beh3QCi2rOt_VHHZZ6hjU2g" 2.0)
+    (marmalade.abc.TRANSFER "buyer-account" "c:z85Gnsq2GGFlAPL4lmU1beh3QCi2rOt_VHHZZ6hjU2g" 2.0)
    ]}])
 
 (env-hash (hash "offer-royalty-0"))

--- a/pact/policies/onchain-manifest-policy/onchain-manifest-policy.repl
+++ b/pact/policies/onchain-manifest-policy/onchain-manifest-policy.repl
@@ -27,11 +27,10 @@
 (begin-tx)
 (use marmalade.ledger)
 (use marmalade.policy-manager)
-(test-capability (coin.COINBASE))
 (env-data {
   "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
 })
-(coin.coinbase "creator-account" (read-keyset 'creator-guard) 2.0)
+(marmalade.abc.create-account "creator-account" (read-keyset 'creator-guard))
 (commit-tx)
 
 (begin-tx)
@@ -43,7 +42,7 @@
  ,"account": "account"
  ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
-    "fungible": coin
+    "fungible": marmalade.abc
    ,"creator": 'creator-account
    ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty-rate": 0.05

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -27,7 +27,7 @@
 
 
   (define-namespace 'util (sig-keyset) (sig-keyset))
-  (load "../util/fungible-util.pact")
+  (load "../util/fungible-util.pact")  
 (commit-tx)
 
 (begin-tx)
@@ -52,6 +52,7 @@
   (load "../policy-manager/policy-manager.pact")
   (load "../ledger.pact")
   (load "../marmalade-util/util-v1.pact")
+  (load "../test/abc.pact")
 (commit-tx)
 
 (begin-tx "load concrete-polices")

--- a/pact/test/abc.pact
+++ b/pact/test/abc.pact
@@ -1,0 +1,167 @@
+(namespace (read-msg 'ns))
+(module abc GOVERNANCE
+
+  (implements fungible-v2)
+  (use util.fungible-util)
+
+  (defschema entry
+    balance:decimal
+    guard:guard)
+
+  (deftable ledger:{entry})
+
+  (defcap GOVERNANCE ()
+    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+
+  (defcap DEBIT (sender:string)
+    (enforce-guard (at 'guard (read ledger sender))))
+
+  (defcap CREDIT (receiver:string) true)
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce-valid-transfer sender receiver (precision) amount)
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver))
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal)
+  )
+
+  (defconst MINIMUM_PRECISION 14)
+
+  (defun enforce-unit:bool (amount:decimal)
+    (enforce-precision (precision) amount))
+
+  (defun create-account:string
+    ( account:string
+      guard:guard
+    )
+    (enforce-valid-account account)
+    (insert ledger account
+      { "balance" : 0.0
+      , "guard"   : guard
+      })
+    )
+
+  (defun get-balance:decimal (account:string)
+    (at 'balance (read ledger account))
+  )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account:string )
+    (with-read ledger account
+      { "balance" := bal
+      , "guard" := g }
+      { "account" : account
+      , "balance" : bal
+      , "guard": g })
+    )
+
+  (defun rotate:string (account:string new-guard:guard)
+    (with-read ledger account
+      { "guard" := old-guard }
+
+      (enforce-guard old-guard)
+
+      (update ledger account
+        { "guard" : new-guard }))
+    )
+
+  (defun fund:string (account:string amount:decimal)
+    ; (with-capability (GOVERNANCE)
+      (with-capability (CREDIT account)
+        (credit account
+          (at 'guard (read ledger account))
+          amount)))
+
+  (defun precision:integer ()
+    MINIMUM_PRECISION)
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-transfer sender receiver (precision) amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read ledger receiver
+        { "guard" := g }
+        (credit receiver g amount))
+      )
+    )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal )
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-transfer sender receiver (precision) amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount))
+    )
+
+  (defun debit:string (account:string amount:decimal)
+
+    (require-capability (DEBIT account))
+    (with-read ledger account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update ledger account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+
+  (defun credit:string (account:string guard:guard amount:decimal)
+
+    (require-capability (CREDIT account))
+    (with-default-read ledger account
+      { "balance" : 0.0, "guard" : guard }
+      { "balance" := balance, "guard" := retg }
+      ; we don't want to overwrite an existing guard with the user-supplied one
+      (enforce (= retg guard)
+        "account guards do not match")
+
+      (write ledger account
+        { "balance" : (+ balance amount)
+        , "guard"   : retg
+        })
+      ))
+
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
+    (step (enforce false "cross chain not supported"))
+    )
+
+)
+
+(if (read-msg 'upgrade)
+  ["upgrade"]
+  [(create-table ledger)]
+)


### PR DESCRIPTION
Updating the repl tests so they are not using the coin contract but a random dummy fungible. This will prevent any errors with hardcoded coin contracts in the code.