### PR TITLE
Removes adjustable policies, replace `token-policies` with list of concrete and immutable policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ The main contract in Marmalade is `marmalade.ledger`. This contract stores the t
 
 ### Policy manager
 
-Marmalade V2's new feature is a policy manager. Marmalade tokens now store multiple policies in a `token-policies` format, instead of a single policy.
-The policy manager makes a distinction between 3 types of policies, concrete, immutable, and adjustable which are explained in detail below. Policy manager acts as a middleware between policies, and runs the `policy::enforce-**` functions.
+Marmalade V2's new feature is a policy manager. Marmalade tokens now store multiple policies in a `policies` format, instead of a single policy.
+All policies are immutable, meaning tokens will permanently store and run the rules that are attached when the token was created. However, the policy manager makes a distinction of some policies we call, `concrete-policies`. Concrete policies are the policies that policy manager knows about, and adds extra logic to run exceptions for some of the policies, that were thought to be most-used features.
+
+Policy manager acts as a middleware between policies, and runs the `policy::enforce-**` functions.
 
 ## Using Policies
 
@@ -26,18 +28,6 @@ The policy manager makes a distinction between 3 types of policies, concrete, im
     guard-policy:bool
   )
 ```
-
-```
-  (defschema token-policies
-    concrete-policies:object{concrete-policy}
-    immutable-policies:[module{token-policy-v2}]
-    adjustable-policies:[module{token-policy-v2}]
-  )
-```
-
-- `concrete-policies` store boolean values that represent if the token uses the concrete-policy or not. Immutable.
-- `immutable-policies` store additional immutable policies that the token chooses to be bound with.
-- `adjustable-policies` store policies that can be rotated by the token owner. Fractional tokens cannot rotate.
 
 ### Concrete Policies
 
@@ -330,16 +320,11 @@ The reason for hashing the token-details is to capture all the data on the ledge
 
 ## Rationale
 
-### Why the Manifest was Replaced by URI 
+### Why the Manifest was Replaced by URI
 
 We decided to replace the manifest schema with a URI-based schema. The new schema for NFT metadata is a simple JSON schema that describes the properties of the metadata. This schema enables compatibility with various marketplaces and wallets, making Marmalade tokens more interoperable. By utilising a URI-based schema, Marmalade tokens can improve scalability, and provide greater flexibility for developers and most of all simplicity of usage in general.
 
 The decision to move NFT metadata off-chain and use a widely accepted standard for the metadata schema is a positive step for Marmalade tokens.
-
-
-
-
-
 
 ## IPFS Storage Guide
 
@@ -348,60 +333,58 @@ This guide provides our recommend approach to storing metadata and image assets 
 ### Storing Collections: Step-by-Step Guide
 
 1.  **Image Upload to IPFS:**
-    
-    -  Uploading your image assets folder to IPFS, adopting sequential numbering for streamlined referencing (e.g., "1.jpg, 2.jpg...").
+
+    - Uploading your image assets folder to IPFS, adopting sequential numbering for streamlined referencing (e.g., "1.jpg, 2.jpg...").
+
 2.  **Metadata Update:**
-    
-    -  After the upload, capture the CID for the assets folder (e.g., "Bayfol...").
-    -  Proceed to update the metadata files, correlating the image property with the path to CID (e.g., "ipfs://Bayfol.../1.jpg").
+
+    - After the upload, capture the CID for the assets folder (e.g., "Bayfol...").
+    - Proceed to update the metadata files, correlating the image property with the path to CID (e.g., "ipfs://Bayfol.../1.jpg").
+
 3.  **Metadata Upload to IPFS:**
-    
-    -  Upload the metadata files to IPFS, maintaining sequential numbering that corresponds with the asset (e.g., "1.json, 2.json...").
-    -  Retrieve the CID for the uploaded metadata folder (e.g., "Baymetx...).
+
+    - Upload the metadata files to IPFS, maintaining sequential numbering that corresponds with the asset (e.g., "1.json, 2.json...").
+    - Retrieve the CID for the uploaded metadata folder (e.g., "Baymetx...).
+
 4.  **Finalizing URI:**
-    
-    -  Merge the metadata folder CID (e.g., "Baymetx...") with the respective filename and extension to construct a comprehensive URI (e.g., "ipfs://Baymetx.../1.json").
-   
+
+    - Merge the metadata folder CID (e.g., "Baymetx...") with the respective filename and extension to construct a comprehensive URI (e.g., "ipfs://Baymetx.../1.json").
 
 ### Example:
 
- - **uri:** [ipfs://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna/1.json](ipfs://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna/1.json)
-   
- - **gateway:** [[click here]](https://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna.ipfs.dweb.link/1.json)
+- **uri:** [ipfs://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna/1.json](ipfs://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna/1.json)
 
+- **gateway:** [[click here]](https://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna.ipfs.dweb.link/1.json)
 
- - **collection-asset-folder:** ipfs://bafybeie4ktsgx4x3gnpvo2uptngez4cvvqdq75iimpnukvpee2x34yp6jm
+* **collection-asset-folder:** ipfs://bafybeie4ktsgx4x3gnpvo2uptngez4cvvqdq75iimpnukvpee2x34yp6jm
 
-   
- - **collection-asset-folder-gateway:** [[click here]](https://bafybeie4ktsgx4x3gnpvo2uptngez4cvvqdq75iimpnukvpee2x34yp6jm.ipfs.dweb.link/)
- 
- - **collection-metadata-folder:** ipfs://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna
+- **collection-asset-folder-gateway:** [[click here]](https://bafybeie4ktsgx4x3gnpvo2uptngez4cvvqdq75iimpnukvpee2x34yp6jm.ipfs.dweb.link/)
 
+- **collection-metadata-folder:** ipfs://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna
 
- - **collection-metadata-folder-gateway:** [[click here]](https://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna.ipfs.dweb.link/)
-
-
-
+* **collection-metadata-folder-gateway:** [[click here]](https://bafybeig4ihtm2phax2eodfpubwy467szuiieqafkoywp5khzt6cz2hqrna.ipfs.dweb.link/)
 
 ### Single NFT Storage: Step-by-Step Guide
 
 1.  **Image and Metadata Upload to IPFS:**
-    
-    -  Upload the image asset to IPFS.
+
+    - Upload the image asset to IPFS.
+
 2.  **Metadata Update:**
-    
-    -  Upon successful upload, retrieve the CID for the asset (e.g., "Bayfabc...").
-    -  Revise the metadata files, matching the image property with the path to CID (e.g., "ipfs://Bayfabc.../1.jpg").
+
+    - Upon successful upload, retrieve the CID for the asset (e.g., "Bayfabc...").
+    - Revise the metadata files, matching the image property with the path to CID (e.g., "ipfs://Bayfabc.../1.jpg").
+
 3.  **Metadata Upload to IPFS:**
-    -  Upload the metadata file to IPFS.
+    - Upload the metadata file to IPFS.
 4.  **Finalizing URI:**
-    -  Retrieve the path containing the CID for the uploaded metadata file (e.g., "ipfs://Bayfxyz.../metadata.json")
+    - Retrieve the path containing the CID for the uploaded metadata file (e.g., "ipfs://Bayfxyz.../metadata.json")
 
 ### Example:
 
- - **uri:** [ipfs://bafyreiainnf575ivbxffep3xqx4d4v2jrpyz4yrggylfp5i7lru7zpfese/metadata.json](ipfs://bafyreiainnf575ivbxffep3xqx4d4v2jrpyz4yrggylfp5i7lru7zpfese/metadata.json)
-   
- - **gateway-link:** [[click here]](https://bafyreiainnf575ivbxffep3xqx4d4v2jrpyz4yrggylfp5i7lru7zpfese.ipfs.dweb.link/metadata.json)
+- **uri:** [ipfs://bafyreiainnf575ivbxffep3xqx4d4v2jrpyz4yrggylfp5i7lru7zpfese/metadata.json](ipfs://bafyreiainnf575ivbxffep3xqx4d4v2jrpyz4yrggylfp5i7lru7zpfese/metadata.json)
+
+- **gateway-link:** [[click here]](https://bafyreiainnf575ivbxffep3xqx4d4v2jrpyz4yrggylfp5i7lru7zpfese.ipfs.dweb.link/metadata.json)
 
 ### Metadata Structure
 
@@ -412,7 +395,6 @@ In this schema, the `image` property should contain a link to the image on IPFS 
 ### Token Creation in the Ledger
 
 When creating a token in the ledger, you should use the `create-token` function. The link obtained from IPFS (.json) serves as the URI supplied to create a token within the ledger:
-
 
     (defun create-token:bool
         ( id:string

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -145,16 +145,6 @@
     (enforce-ledger)
   )
 
-  (defun enforce-crosschain:bool
-    ( token:object{token-info}
-      sender:string
-      guard:guard
-      receiver:string
-      target-chain:string
-      amount:decimal )
-    (enforce false "Transfer prohibited")
-  )
-
   ;;UTILITY FUNCTIONS
 
   (defun create-collection-id (collection-name:string)

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -84,6 +84,7 @@
          ,"collection-id" : collection-id
       })
     ))
+    true
   )
 
   (defun enforce-mint:bool

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -39,6 +39,10 @@
     @event
     true)
 
+  (defcap TOKEN_COLLECTION:bool (token-id:string collection-id:string)
+    @event
+    true)
+
   (defun enforce-ledger:bool ()
     (enforce-guard (marmalade.ledger.ledger-guard))
     true
@@ -83,7 +87,8 @@
         { "id" : token-id
          ,"collection-id" : collection-id
       })
-    ))
+    )
+    (emit-event (TOKEN_COLLECTION token-id collection-id)))
     true
   )
 

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -71,7 +71,7 @@
 
   (env-sigs [
     { 'key: 'account1
-    ,'caps: [(marmalade.ledger.MINT "t:v8PHL_65vsRJva2bXCERDewJuBWgnWr0uTASq4VABEU" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT (read-msg 'token-id) "k:account" 1.0)]
     }])
 
   (expect "mint a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -71,7 +71,7 @@
 
   (env-sigs [
     { 'key: 'account1
-    ,'caps: [(marmalade.ledger.MINT "t:vcih_tznz0xRme7Uc1J2I8kxHQWX7BBAIenUrijyGvA" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT "t:v8PHL_65vsRJva2bXCERDewJuBWgnWr0uTASq4VABEU" "k:account" 1.0)]
     }])
 
   (expect "mint a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -2,7 +2,7 @@
 (load "../../policy-manager/policy-manager.repl")
 
 (begin-tx)
-(use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+(use marmalade.policy-manager [QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 (commit-tx)
 
 (begin-tx)

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -2,30 +2,10 @@
 (load "../../policy-manager/policy-manager.repl")
 
 (begin-tx)
-(use kip.token-policy-v2 [token-policies concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
-
-(module util GOV
-  (defcap GOV () true)
-
-  (defconst DEFAULT_COLLECTION_WITH_ROYALTY:object{concrete-policy}
-    { 'quote-policy: true
-     ,'non-fungible-policy: true
-     ,'royalty-policy: true
-     ,'collection-policy:true
-     ,'guard-policy: true
-    }
-  )
-  (defconst DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY:object{token-policies}
-    { 'concrete-policies:DEFAULT_COLLECTION_WITH_ROYALTY
-     ,'immutable-policies: []
-     ,'adjustable-policies:[]
-    })
-)
+(use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 (commit-tx)
 
 (begin-tx)
-  (use marmalade.ledger)
-  (use marmalade.policy-manager)
   (env-data {
     "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
   })
@@ -35,8 +15,9 @@
 (begin-tx "Creating collection")
   (use marmalade.ledger)
   (use marmalade.policy-manager)
+  (use marmalade.util-v1)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY } )
+    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -61,15 +42,17 @@
 (begin-tx "Create token without operator guard fails")
   (use marmalade.ledger)
   (use marmalade.policy-manager)
+  (use marmalade.util-v1)
 
  (expect-failure "create token fails if operator guard isn't present"
    "Keyset failure"
-   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY ))
+   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
 (rollback-tx)
 
 (begin-tx "Create token")
   (use marmalade.ledger)
   (use marmalade.policy-manager)
+  (use marmalade.util-v1)
 
   (env-sigs [
     { 'key: 'operator
@@ -78,7 +61,7 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY ))
+    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
 
 (commit-tx)
 
@@ -88,7 +71,7 @@
 
   (env-sigs [
     { 'key: 'account1
-    ,'caps: [(marmalade.ledger.MINT "t:4ROy-Sx2Q8BrkGYQdFE9UAIJku9kpMXejUL3GnA0j3A" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT "t:vcih_tznz0xRme7Uc1J2I8kxHQWX7BBAIenUrijyGvA" "k:account" 1.0)]
     }])
 
   (expect "mint a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
@@ -117,9 +100,11 @@
 (begin-tx "Creating collection and validate size")
   (use marmalade.ledger)
   (use marmalade.policy-manager)
+  (use marmalade.util-v1)
+
   (env-data {
-    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY } )
-  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY } )
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -143,19 +128,21 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY ))
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
 
   (expect-failure "creating another token will exceed collection-size"
     "Exceeds collection size"
-    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY ))
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
 (rollback-tx)
 
 (begin-tx "Create collection with unlimited size and add two tokens")
   (use marmalade.ledger)
   (use marmalade.policy-manager)
+  (use marmalade.util-v1)
+
   (env-data {
-    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY } )
-  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY } )
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -179,9 +166,9 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY ))
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
 
   (expect "create another token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" util.DEFAULT_COLLECTION_POLICIES_WITH_ROYALTY ))
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
 (rollback-tx)

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact
@@ -21,7 +21,7 @@
 
   (defconst MARKETPLACE-FEE-MSG-KEY "marketplace-fee"
     @doc "Payload field for marketplace fee spec")
-  
+
   (defconst BID_ID-MSG-KEY "bid-id"
     @doc "Payload field for bid-id")
 
@@ -41,7 +41,7 @@
 
   (defschema quote-schema
     id:string
-    spec:object{quote-spec}    
+    spec:object{quote-spec}
   )
 
   (defun get-quote:object{quote-schema} (sale-id:string)
@@ -49,8 +49,8 @@
   )
 
   (defun accept-bid:bool (
-    bid-id:string 
-    buyer:string 
+    bid-id:string
+    buyer:string
     sale-id:string
     escrow-account:string
     escrow-guard:guard)

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
@@ -2,7 +2,7 @@
 (load "../../policy-manager/policy-manager.repl")
 (env-exec-config [])
 (begin-tx "Create a fungible token")
-(use kip.token-policy-v2 [token-policies concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+(use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 
 (module util GOV
   (defcap GOV () true)
@@ -16,11 +16,6 @@
     }
   )
 
-  (defconst QUOTE_ONLY_POLICIES:object{token-policies}
-    { 'concrete-policies:QUOTE_ONLY
-     ,'immutable-policies: []
-     ,'adjustable-policies:[]
-  })
 )
 (commit-tx)
 
@@ -29,14 +24,14 @@
 (use marmalade.policy-manager)
 (env-exec-config ["DisablePact44"])
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+   "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
   ,"account": "k:account"
   ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
 })
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'token-id) 0 "test-quote-only-uri" util.QUOTE_ONLY_POLICIES ))
+  (create-token (read-msg 'token-id) 0 "test-quote-only-uri" (create-policies util.QUOTE_ONLY)))
 
 (env-sigs [
   { 'key: 'random
@@ -44,7 +39,7 @@
   }])
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+  "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
 })
@@ -60,7 +55,7 @@
   (use marmalade.policy-manager)
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"account": "k:account"
   })
@@ -94,13 +89,14 @@
 
   (env-hash (hash "offer-quote-only-0"))
   (use marmalade.ledger)
+  (use marmalade.policy-manager)
 
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
   })
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
   , "quote": {
       "fungible": marmalade.abc
       ,"price": 2.0
@@ -125,7 +121,7 @@
 
   (env-hash (hash "offer-quote-only-1"))
   (use marmalade.ledger)
-
+  (use marmalade.policy-manager)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
   })
@@ -133,7 +129,7 @@
   (marmalade.abc.fund "k:account" 2.0)
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
   ,"quote": {
     "fungible": marmalade.abc
     ,"price": 2.0
@@ -168,7 +164,7 @@
   (env-sigs
   [{'key:'buyer
     ,'caps: [
-      (BUY (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } ) "k:account" "k:buyer"  1.0 (time  "2023-07-22T11:26:35Z") "v86vqj0OkIZQfD3XGETjij1sLjJH7Q6GZBZJeytDsEo")
+      (BUY (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} ) "k:account" "k:buyer"  1.0 (time  "2023-07-22T11:26:35Z") "v86vqj0OkIZQfD3XGETjij1sLjJH7Q6GZBZJeytDsEo")
       (marmalade.abc.TRANSFER "k:buyer" "c:cbnfX-2IcN_in1gOZpdheAlkbERuqFIUNOYE8egBx38" 2.0)
     ]}])
 
@@ -196,14 +192,14 @@
 
   (env-hash (hash "offer-quote-only-1"))
   (use marmalade.ledger)
-
+  (use marmalade.policy-manager)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
   })
   (marmalade.abc.create-account "k:account" (read-keyset 'seller-guard))
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
   ,"quote": {
     "fungible": marmalade.abc
     ,"price": 2.0
@@ -236,7 +232,7 @@
   (env-sigs
   [{'key:'buyer
     ,'caps: [
-      (BUY (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } ) "k:account" "k:buyer"  1.0 (time  "2023-07-22T11:26:35Z") "v86vqj0OkIZQfD3XGETjij1sLjJH7Q6GZBZJeytDsEo")
+      (BUY (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} ) "k:account" "k:buyer"  1.0 (time  "2023-07-22T11:26:35Z") "v86vqj0OkIZQfD3XGETjij1sLjJH7Q6GZBZJeytDsEo")
       (marmalade.abc.TRANSFER "k:buyer" "c:cbnfX-2IcN_in1gOZpdheAlkbERuqFIUNOYE8egBx38" 2.0)
     ]}])
 
@@ -263,14 +259,14 @@
 
   (env-hash (hash "offer-bidding-1"))
   (use marmalade.ledger)
-
+  (use marmalade.policy-manager)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
   })
   (marmalade.abc.create-account "k:account" (read-keyset 'seller-guard))
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
   ,"quote": {
     "fungible": marmalade.abc
     ,"price": 10.0
@@ -290,7 +286,7 @@
     (sale (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z")))
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } )
+    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
     ,"sale-id": "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8"
     ,"bidder-guard": {"keys": ["bidder"], "pred": "keys-all"}
   })
@@ -345,7 +341,7 @@
 
   (env-hash (hash "accept-bidding-1"))
   (use marmalade.fungible-quote-policy-v1)
-
+  (use marmalade.policy-manager)
   (env-sigs [
     { 'key: 'seller
     ,'caps: [
@@ -368,7 +364,7 @@
   (env-sigs [
     { 'key: 'bidder
     ,'caps: [
-      (marmalade.ledger.BUY (marmalade.ledger.create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: util.QUOTE_ONLY_POLICIES } ) "k:account" "k:bidder"  1.0 (time  "2023-07-22T11:26:35Z") "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8")
+      (marmalade.ledger.BUY (marmalade.ledger.create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} ) "k:account" "k:bidder"  1.0 (time  "2023-07-22T11:26:35Z") "FRVsiHGeVPQNZEpnJ8MrF6_fpB0o2tj-xztJRHQe_m8")
       ]
     },
     { 'key: 'account

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
@@ -21,7 +21,7 @@
 
 (begin-tx)
 (use marmalade.ledger)
-(use marmalade.policy-manager)
+(use marmalade.util-v1)
 (env-exec-config ["DisablePact44"])
 (env-data {
    "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
@@ -52,7 +52,7 @@
 
 (begin-tx "mint for the second time")
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-quote-only-uri", 'precision: 0, 'policies: (create-policies util.QUOTE_ONLY)} )
@@ -89,7 +89,7 @@
 
   (env-hash (hash "offer-quote-only-0"))
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
 
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -121,7 +121,7 @@
 
   (env-hash (hash "offer-quote-only-1"))
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
   })
@@ -192,7 +192,7 @@
 
   (env-hash (hash "offer-quote-only-1"))
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
   })
@@ -259,7 +259,7 @@
 
   (env-hash (hash "offer-bidding-1"))
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
   })
@@ -341,7 +341,7 @@
 
   (env-hash (hash "accept-bidding-1"))
   (use marmalade.fungible-quote-policy-v1)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
   (env-sigs [
     { 'key: 'seller
     ,'caps: [

--- a/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
+++ b/pact/concrete-policies/fungible-quote-policy/fungible-quote-policy-v1.repl
@@ -2,12 +2,13 @@
 (load "../../policy-manager/policy-manager.repl")
 (env-exec-config [])
 (begin-tx "Create a fungible token")
-(use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+(use marmalade.policy-manager [QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+(use marmalade.util-v1 [concrete-policy-bool])
 
 (module util GOV
   (defcap GOV () true)
 
-  (defconst QUOTE_ONLY:object{concrete-policy}
+  (defconst QUOTE_ONLY:object{concrete-policy-bool}
     { 'quote-policy: true
      ,'non-fungible-policy: false
      ,'royalty-policy: false

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -41,15 +41,15 @@
   )
 
   (defun get-mint-guard:guard (token-id:string)
-    (with-read guards token-id {
-      "mint-guard":= mint-guard
+    (with-read policy-guards token-id {
+      'mint-guard:= mint-g
     }
-    mint-guard
+    mint-g
     )
   )
 
   (defun get-burn-guard:guard (token-id:string)
-    (with-read guards token-id {
+    (with-read policy-guards token-id {
       "burn-guard":= burn-guard
     }
     burn-guard
@@ -57,7 +57,7 @@
   )
 
   (defun get-sale-guard:guard (token-id:string)
-    (with-read guards token-id {
+    (with-read policy-guards token-id {
       "sale-guard":= sale-guard
     }
     sale-guard
@@ -65,7 +65,7 @@
   )
 
   (defun get-transfer-guard:guard (token-id:string)
-    (with-read guards token-id {
+    (with-read policy-guards token-id {
       "transfer-guard":= transfer-guard
     }
     transfer-guard

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -164,17 +164,6 @@
     (enforce-ledger)
     (enforce-guard (at TRANSFER_GUARD (get-guards token)))
   )
-
-  (defun enforce-crosschain:bool
-    ( token:object{token-info}
-      sender:string
-      guard:guard
-      receiver:string
-      target-chain:string
-      amount:decimal )
-    (enforce-ledger)
-    (enforce false "Transfer prohibited")
-  )
 )
 
 (if (read-msg 'upgrade)

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -9,7 +9,6 @@
 
 (begin-tx "Create token without mint guard")
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
   (use marmalade.util-v1)
 (env-data {
    "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
@@ -19,13 +18,12 @@
 
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade.ledger.MINT "t:uucCnqSCIiWJPPto-snb1Dzbvm2Tuu77b9NSJf4F60c" "k:account" 1.0)]
+   ,'caps: [(marmalade.ledger.MINT "t:UHU7ilVZEH0GxsPdfO39DN-_ZteJd0rX9EaiL34stT4" "k:account" 1.0)]
   }])
 
 (expect "create token succeeds without mint-guard"
  true
  (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ))
-(env-keys ["marmalade-admin"])
 
 (expect "Mint token succeeds without mint-guard"
   true
@@ -36,7 +34,6 @@
 
 (begin-tx "Create token without operator guard fails")
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
   (use marmalade.util-v1)
 (env-data {
    "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
@@ -51,7 +48,7 @@
 
  (env-sigs [
    { 'key: 'mint-false
-    ,'caps: [(marmalade.ledger.MINT "t:uucCnqSCIiWJPPto-snb1Dzbvm2Tuu77b9NSJf4F60c" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT "t:UHU7ilVZEH0GxsPdfO39DN-_ZteJd0rX9EaiL34stT4" "k:account" 1.0)]
    }])
 
 (expect-failure "Mint token fails without mint-guard"
@@ -60,7 +57,7 @@
 
 (env-sigs [
   { 'key: 'mint
-   ,'caps: [(marmalade.ledger.MINT "t:uucCnqSCIiWJPPto-snb1Dzbvm2Tuu77b9NSJf4F60c" "k:account" 1.0)]
+   ,'caps: [(marmalade.ledger.MINT "t:UHU7ilVZEH0GxsPdfO39DN-_ZteJd0rX9EaiL34stT4" "k:account" 1.0)]
   }])
 
 (expect "Mint token fails without mint-guard"

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -18,7 +18,7 @@
 
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade.ledger.MINT "t:UHU7ilVZEH0GxsPdfO39DN-_ZteJd0rX9EaiL34stT4" "k:account" 1.0)]
+   ,'caps: [(marmalade.ledger.MINT (read-msg 'token-id) "k:account" 1.0)]
   }])
 
 (expect "create token succeeds without mint-guard"
@@ -48,7 +48,7 @@
 
  (env-sigs [
    { 'key: 'mint-false
-    ,'caps: [(marmalade.ledger.MINT "t:UHU7ilVZEH0GxsPdfO39DN-_ZteJd0rX9EaiL34stT4" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT (read-msg 'token-id) "k:account" 1.0)]
    }])
 
 (expect-failure "Mint token fails without mint-guard"
@@ -57,7 +57,7 @@
 
 (env-sigs [
   { 'key: 'mint
-   ,'caps: [(marmalade.ledger.MINT "t:UHU7ilVZEH0GxsPdfO39DN-_ZteJd0rX9EaiL34stT4" "k:account" 1.0)]
+   ,'caps: [(marmalade.ledger.MINT (read-msg 'token-id) "k:account" 1.0)]
   }])
 
 (expect "Mint token fails without mint-guard"

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -2,7 +2,7 @@
 (load "../../policy-manager/policy-manager.repl")
 
 (begin-tx)
-(use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+(use marmalade.policy-manager [QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 
 (commit-tx)
 

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -2,52 +2,29 @@
 (load "../../policy-manager/policy-manager.repl")
 
 (begin-tx)
-(use kip.token-policy-v2 [token-policies concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
-
-(module util GOV
-  (defcap GOV () true)
-
-  (defconst DEFAULT:object{concrete-policy}
-    { 'quote-policy: true
-     ,'non-fungible-policy: true
-     ,'royalty-policy: false
-     ,'collection-policy:false
-     ,'guard-policy: true
-    }
-  )
-
-  (defconst DEFAULT_POLICIES_WITH_GUARD:object{token-policies}
-    { 'concrete-policies:DEFAULT
-     ,'immutable-policies: []
-     ,'adjustable-policies:[]
-  })
-)
+(use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 
 (commit-tx)
 
-(begin-tx)
-  (use marmalade.ledger)
-  (use marmalade.policy-manager)
-(commit-tx)
 
 (begin-tx "Create token without mint guard")
   (use marmalade.ledger)
   (use marmalade.policy-manager)
-
+  (use marmalade.util-v1)
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: util.DEFAULT_POLICIES_WITH_GUARD } )
+   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
 })
 
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade.ledger.MINT "t:oj7qLIkldM7MwNgEz5jIJy_VunqiLuqhgvmIFVLtaRI" "k:account" 1.0)]
+   ,'caps: [(marmalade.ledger.MINT "t:uucCnqSCIiWJPPto-snb1Dzbvm2Tuu77b9NSJf4F60c" "k:account" 1.0)]
   }])
 
 (expect "create token succeeds without mint-guard"
  true
- (create-token (read-msg 'token-id) 0 "test-default-guard" util.DEFAULT_POLICIES_WITH_GUARD ))
+ (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ))
 
 (expect "Mint token succeeds without mint-guard"
   true
@@ -59,9 +36,9 @@
 (begin-tx "Create token without operator guard fails")
   (use marmalade.ledger)
   (use marmalade.policy-manager)
-
+  (use marmalade.util-v1)
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: util.DEFAULT_POLICIES_WITH_GUARD } )
+   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
   ,"account": "k:account"
   ,"mint-guard": {"keys": ["mint"], "pred": "keys-all"}
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -69,11 +46,11 @@
 
 (expect "create token succeeds with mint-guard"
  true
- (create-token (read-msg 'token-id) 0 "test-default-guard" util.DEFAULT_POLICIES_WITH_GUARD ))
+ (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ))
 
  (env-sigs [
    { 'key: 'mint-false
-    ,'caps: [(marmalade.ledger.MINT "t:oj7qLIkldM7MwNgEz5jIJy_VunqiLuqhgvmIFVLtaRI" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT "t:uucCnqSCIiWJPPto-snb1Dzbvm2Tuu77b9NSJf4F60c" "k:account" 1.0)]
    }])
 
 (expect-failure "Mint token fails without mint-guard"
@@ -82,7 +59,7 @@
 
 (env-sigs [
   { 'key: 'mint
-   ,'caps: [(marmalade.ledger.MINT "t:oj7qLIkldM7MwNgEz5jIJy_VunqiLuqhgvmIFVLtaRI" "k:account" 1.0)]
+   ,'caps: [(marmalade.ledger.MINT "t:uucCnqSCIiWJPPto-snb1Dzbvm2Tuu77b9NSJf4F60c" "k:account" 1.0)]
   }])
 
 (expect "Mint token fails without mint-guard"

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -25,6 +25,7 @@
 (expect "create token succeeds without mint-guard"
  true
  (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ))
+(env-keys ["marmalade-admin"])
 
 (expect "Mint token succeeds without mint-guard"
   true

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -77,15 +77,4 @@
       sale-id:string )
     (enforce-ledger)
   )
-
-  (defun enforce-crosschain:bool
-    ( token:object{token-info}
-      sender:string
-      guard:guard
-      receiver:string
-      target-chain:string
-      amount:decimal )
-    (enforce-ledger)
-    (enforce false "Transfer prohibited")
-  )
 )

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -20,7 +20,7 @@
 
 (begin-tx)
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
   (env-data {
     "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
   })
@@ -29,7 +29,7 @@
 
 (begin-tx)
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
   (env-data {
     "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } )
     ,"account": "k:account"
@@ -41,7 +41,7 @@
 
 (begin-tx "Create a non-fungible token")
   (use marmalade.ledger)
-  (use marmalade.policy-manager)
+  (use marmalade.util-v1)
   (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) )
 (commit-tx)
 
@@ -50,7 +50,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-     ,'caps: [(marmalade.ledger.MINT "t:YJJSttfw3EWOaMZHWyIbCGhj1ZVm2FuO8tRjGFekDzo" "k:account" 5.0)
+     ,'caps: [(marmalade.ledger.MINT "t:DI4FHziasc_JhUMhxS366zMJ3KKDXWUcytBo6RhPnBQ" "k:account" 5.0)
     ]
     }])
 
@@ -63,7 +63,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-    ,'caps: [(marmalade.ledger.MINT "t:YJJSttfw3EWOaMZHWyIbCGhj1ZVm2FuO8tRjGFekDzo" "k:account" 0.5)]
+    ,'caps: [(marmalade.ledger.MINT "t:DI4FHziasc_JhUMhxS366zMJ3KKDXWUcytBo6RhPnBQ" "k:account" 0.5)]
     }])
 
   (expect-failure "minting with amout of 0.5 fails"
@@ -75,7 +75,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-    ,'caps: [(marmalade.ledger.MINT "t:YJJSttfw3EWOaMZHWyIbCGhj1ZVm2FuO8tRjGFekDzo" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT "t:DI4FHziasc_JhUMhxS366zMJ3KKDXWUcytBo6RhPnBQ" "k:account" 1.0)]
     }])
 
   (expect "minting succeeds"
@@ -87,7 +87,7 @@
   (use marmalade.ledger)
     (env-sigs [
       { 'key: 'account
-      ,'caps: [(marmalade.ledger.BURN "t:YJJSttfw3EWOaMZHWyIbCGhj1ZVm2FuO8tRjGFekDzo" "k:account" 1.0)]
+      ,'caps: [(marmalade.ledger.BURN "t:DI4FHziasc_JhUMhxS366zMJ3KKDXWUcytBo6RhPnBQ" "k:account" 1.0)]
       }])
 
     (expect-failure "Burning is not allowed"

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -2,12 +2,13 @@
 (load "../../policy-manager/policy-manager.repl")
 
 (begin-tx)
-  (use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
-
+  (use marmalade.policy-manager [QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+  (use marmalade.util-v1 [concrete-policy-bool])
+  
   (module util GOV
     (defcap GOV () true)
 
-    (defconst DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY:object{concrete-policy}
+    (defconst DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY:object{concrete-policy-bool}
       { 'quote-policy: false
        ,'non-fungible-policy: true
        ,'royalty-policy: false

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -2,7 +2,7 @@
 (load "../../policy-manager/policy-manager.repl")
 
 (begin-tx)
-  (use kip.token-policy-v2 [token-policies concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+  (use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 
   (module util GOV
     (defcap GOV () true)
@@ -15,11 +15,6 @@
        ,'guard-policy: true
       }
     )
-    (defconst DEFAULT_NON_FUNGIBLE_POLICIES:object{token-policies}
-      { 'concrete-policies:DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY
-       ,'immutable-policies: []
-       ,'adjustable-policies:[]
-      })
   )
 (commit-tx)
 
@@ -35,9 +30,8 @@
 (begin-tx)
   (use marmalade.ledger)
   (use marmalade.policy-manager)
-
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: util.DEFAULT_NON_FUNGIBLE_POLICIES } )
+    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } )
     ,"account": "k:account"
     ,"nfp-mint-guard": {"keys": ["account"], "pred": "keys-all"}
     ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -47,8 +41,8 @@
 
 (begin-tx "Create a non-fungible token")
   (use marmalade.ledger)
-
-  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" util.DEFAULT_NON_FUNGIBLE_POLICIES )
+  (use marmalade.policy-manager)
+  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) )
 (commit-tx)
 
 (begin-tx "Mint with a supply other then 1 fails ")
@@ -56,7 +50,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-     ,'caps: [(marmalade.ledger.MINT "t:ql_vIepldcYgTSOzuW0VtvdQXDP7_EWP4g-jKL9mxUM" "k:account" 5.0)
+     ,'caps: [(marmalade.ledger.MINT "t:YJJSttfw3EWOaMZHWyIbCGhj1ZVm2FuO8tRjGFekDzo" "k:account" 5.0)
     ]
     }])
 
@@ -69,7 +63,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-    ,'caps: [(marmalade.ledger.MINT "t:ql_vIepldcYgTSOzuW0VtvdQXDP7_EWP4g-jKL9mxUM" "k:account" 0.5)]
+    ,'caps: [(marmalade.ledger.MINT "t:YJJSttfw3EWOaMZHWyIbCGhj1ZVm2FuO8tRjGFekDzo" "k:account" 0.5)]
     }])
 
   (expect-failure "minting with amout of 0.5 fails"
@@ -81,7 +75,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-    ,'caps: [(marmalade.ledger.MINT "t:ql_vIepldcYgTSOzuW0VtvdQXDP7_EWP4g-jKL9mxUM" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT "t:YJJSttfw3EWOaMZHWyIbCGhj1ZVm2FuO8tRjGFekDzo" "k:account" 1.0)]
     }])
 
   (expect "minting succeeds"
@@ -93,7 +87,7 @@
   (use marmalade.ledger)
     (env-sigs [
       { 'key: 'account
-      ,'caps: [(marmalade.ledger.BURN "t:ql_vIepldcYgTSOzuW0VtvdQXDP7_EWP4g-jKL9mxUM" "k:account" 1.0)]
+      ,'caps: [(marmalade.ledger.BURN "t:YJJSttfw3EWOaMZHWyIbCGhj1ZVm2FuO8tRjGFekDzo" "k:account" 1.0)]
       }])
 
     (expect-failure "Burning is not allowed"

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -50,7 +50,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-     ,'caps: [(marmalade.ledger.MINT "t:DI4FHziasc_JhUMhxS366zMJ3KKDXWUcytBo6RhPnBQ" "k:account" 5.0)
+     ,'caps: [(marmalade.ledger.MINT (read-msg 'token-id) "k:account" 5.0)
     ]
     }])
 
@@ -63,7 +63,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-    ,'caps: [(marmalade.ledger.MINT "t:DI4FHziasc_JhUMhxS366zMJ3KKDXWUcytBo6RhPnBQ" "k:account" 0.5)]
+    ,'caps: [(marmalade.ledger.MINT (read-msg 'token-id) "k:account" 0.5)]
     }])
 
   (expect-failure "minting with amout of 0.5 fails"
@@ -75,7 +75,7 @@
   (use marmalade.ledger)
   (env-sigs [
     { 'key: 'account
-    ,'caps: [(marmalade.ledger.MINT "t:DI4FHziasc_JhUMhxS366zMJ3KKDXWUcytBo6RhPnBQ" "k:account" 1.0)]
+    ,'caps: [(marmalade.ledger.MINT (read-msg 'token-id) "k:account" 1.0)]
     }])
 
   (expect "minting succeeds"
@@ -87,7 +87,7 @@
   (use marmalade.ledger)
     (env-sigs [
       { 'key: 'account
-      ,'caps: [(marmalade.ledger.BURN "t:DI4FHziasc_JhUMhxS366zMJ3KKDXWUcytBo6RhPnBQ" "k:account" 1.0)]
+      ,'caps: [(marmalade.ledger.BURN (read-msg 'token-id) "k:account" 1.0)]
       }])
 
     (expect-failure "Burning is not allowed"

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -4,7 +4,7 @@
 (begin-tx)
   (use marmalade.policy-manager [QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
   (use marmalade.util-v1 [concrete-policy-bool])
-  
+
   (module util GOV
     (defcap GOV () true)
 

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -8,10 +8,12 @@
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
 
   (use marmalade.policy-manager)
+  (use marmalade.policy-manager [QUOTE_POLICY])
   (use marmalade.fungible-quote-policy-v1)
   (use marmalade.fungible-quote-policy-interface-v1 [quote-spec quote-schema])
   (implements kip.token-policy-v2)
-  (use kip.token-policy-v2 [token-info QUOTE_POLICY])
+  (use kip.token-policy-v2 [token-info])
+
 
   (defschema royalty-schema
     fungible:module{fungible-v2}

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -143,17 +143,6 @@
     (enforce false "Transfer prohibited")
   )
 
-  (defun enforce-crosschain:bool
-    ( token:object{token-info}
-      sender:string
-      guard:guard
-      receiver:string
-      target-chain:string
-      amount:decimal )
-    (enforce-ledger)
-    (enforce false "Transfer prohibited")
-  )
-
   (defun enforce-withdraw:bool
     ( token:object{token-info}
       seller:string

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -47,15 +47,16 @@
   (defun enforce-init:bool
     ( token:object{token-info}
     )
-    (enforce (is-used (at 'policies token) QUOTE_POLICY) "quote policy must be turned on")
     (enforce-ledger)
-    (let* ( (spec:object{royalty-schema} (read-msg ROYALTY_SPEC))
+    (let* ( (quote-used:bool (is-used (at 'policies token) QUOTE_POLICY))
+            (spec:object{royalty-schema} (read-msg ROYALTY_SPEC))
             (fungible:module{fungible-v2} (at 'fungible spec))
             (creator:string (at 'creator spec))
             (creator-guard:guard (at 'creator-guard spec))
             (royalty-rate:decimal (at 'royalty-rate spec))
             (creator-details:object (fungible::details creator ))
             )
+      (enforce quote-used "quote policy must be turned on")
       (enforce (=
         (at 'guard creator-details) creator-guard)
         "Creator guard does not match")

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -2,28 +2,7 @@
 (load "../../policy-manager/policy-manager.repl")
 
 (begin-tx)
-(use kip.token-policy-v2 [token-policies concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
-
-(module util GOV
-  (defcap GOV () true)
-
-  (defconst DEFAULT_CONCRETE_POLICY_WITH_ROYALTY:object{concrete-policy}
-    { 'quote-policy: true
-     ,'non-fungible-policy: true
-     ,'royalty-policy: true
-     ,'collection-policy:false
-     ,'guard-policy: true
-    }
-  )
-  (defconst DEFAULT_POLICIES_WITH_ROYALTY:object{token-policies}
-    { 'concrete-policies:DEFAULT_CONCRETE_POLICY_WITH_ROYALTY
-     ,'immutable-policies: []
-     ,'adjustable-policies:[]
-    })
-)
-(commit-tx)
-
-(begin-tx)
+(use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 (use marmalade.ledger)
 (use marmalade.policy-manager)
 (env-data {
@@ -33,9 +12,10 @@
 (commit-tx)
 (begin-tx)
 (use marmalade.ledger)
+(use marmalade.util-v1)
 (use marmalade.policy-manager)
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: util.DEFAULT_POLICIES_WITH_ROYALTY } )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} )
  ,"account": "account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -53,16 +33,20 @@
 (begin-tx)
 (use marmalade.ledger)
 (use marmalade.policy-manager)
+(use marmalade.util-v1)
+
 (expect-failure "create-token with negative royalty rate fails"
   "Invalid royalty rate"
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" util.DEFAULT_POLICIES_WITH_ROYALTY ))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ))
 (rollback-tx)
 
 (begin-tx)
 (use marmalade.ledger)
 (use marmalade.policy-manager)
+(use marmalade.util-v1)
+
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: util.DEFAULT_POLICIES_WITH_ROYALTY } )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -75,11 +59,11 @@
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" util.DEFAULT_POLICIES_WITH_ROYALTY ))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ))
 
 (env-sigs [
   { 'key: 'account
-  ,'caps: [(marmalade.ledger.MINT "t:RrGm1DQPjuSxKHkKNm5kXJf34zo_G9goEycEZ4kk_no" "k:account" 1.0)]
+  ,'caps: [(marmalade.ledger.MINT "t:bNYfmbNGX0gqTrG-PeS9_BsVwVtXmsNDVnUDLs_lQXU" "k:account" 1.0)]
   }])
 
 (expect "mint a default token with quote-policy, non-fungible-policy"
@@ -91,6 +75,8 @@
 
 (env-hash (hash "offer-royalty-0"))
 (use marmalade.ledger)
+(use marmalade.policy-manager)
+(use marmalade.util-v1)
 
 (env-data {
   "seller-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -98,7 +84,7 @@
 (marmalade.abc.create-account "k:account" (read-keyset 'seller-guard))
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: util.DEFAULT_POLICIES_WITH_ROYALTY } )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
  ,"quote": {
    "fungible": marmalade.abc
   ,"price": 2.0
@@ -110,7 +96,7 @@
 (env-sigs [
   { 'key: 'account
    ,'caps: [
-   (marmalade.ledger.OFFER "t:RrGm1DQPjuSxKHkKNm5kXJf34zo_G9goEycEZ4kk_no" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+   (marmalade.ledger.OFFER "t:bNYfmbNGX0gqTrG-PeS9_BsVwVtXmsNDVnUDLs_lQXU" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
    }])
 
 (expect "stat offer by running step 0 of sale"
@@ -135,7 +121,7 @@
 (env-sigs
  [{'key:'buyer
   ,'caps: [
-    (BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: util.DEFAULT_POLICIES_WITH_ROYALTY } ) "k:account" "k:buyer"  1.0 (time  "2023-07-22T11:26:35Z") "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+    (BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (time  "2023-07-22T11:26:35Z") "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
     (marmalade.abc.TRANSFER "k:buyer" "c:z85Gnsq2GGFlAPL4lmU1beh3QCi2rOt_VHHZZ6hjU2g" 2.0)
    ]}])
 

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -4,7 +4,7 @@
 (begin-tx)
 (use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 (use marmalade.ledger)
-(use marmalade.policy-manager)
+
 (env-data {
   "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
 })
@@ -13,7 +13,7 @@
 (begin-tx)
 (use marmalade.ledger)
 (use marmalade.util-v1)
-(use marmalade.policy-manager)
+
 (env-data {
   "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} )
  ,"account": "account"
@@ -32,7 +32,7 @@
 
 (begin-tx)
 (use marmalade.ledger)
-(use marmalade.policy-manager)
+
 (use marmalade.util-v1)
 
 (expect-failure "create-token with negative royalty rate fails"
@@ -42,7 +42,7 @@
 
 (begin-tx)
 (use marmalade.ledger)
-(use marmalade.policy-manager)
+
 (use marmalade.util-v1)
 
 (env-data {
@@ -63,7 +63,7 @@
 
 (env-sigs [
   { 'key: 'account
-  ,'caps: [(marmalade.ledger.MINT "t:bNYfmbNGX0gqTrG-PeS9_BsVwVtXmsNDVnUDLs_lQXU" "k:account" 1.0)]
+  ,'caps: [(marmalade.ledger.MINT "t:fiZhyILqrnz9jeziJru0vYuTkXDLBO17v-LKPu6TLK8" "k:account" 1.0)]
   }])
 
 (expect "mint a default token with quote-policy, non-fungible-policy"
@@ -75,7 +75,7 @@
 
 (env-hash (hash "offer-royalty-0"))
 (use marmalade.ledger)
-(use marmalade.policy-manager)
+
 (use marmalade.util-v1)
 
 (env-data {
@@ -96,7 +96,7 @@
 (env-sigs [
   { 'key: 'account
    ,'caps: [
-   (marmalade.ledger.OFFER "t:bNYfmbNGX0gqTrG-PeS9_BsVwVtXmsNDVnUDLs_lQXU" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+   (marmalade.ledger.OFFER "t:fiZhyILqrnz9jeziJru0vYuTkXDLBO17v-LKPu6TLK8" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
    }])
 
 (expect "stat offer by running step 0 of sale"

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -63,7 +63,7 @@
 
 (env-sigs [
   { 'key: 'account
-  ,'caps: [(marmalade.ledger.MINT "t:fiZhyILqrnz9jeziJru0vYuTkXDLBO17v-LKPu6TLK8" "k:account" 1.0)]
+  ,'caps: [(marmalade.ledger.MINT (read-msg 'token-id) "k:account" 1.0)]
   }])
 
 (expect "mint a default token with quote-policy, non-fungible-policy"
@@ -96,7 +96,7 @@
 (env-sigs [
   { 'key: 'account
    ,'caps: [
-   (marmalade.ledger.OFFER "t:fiZhyILqrnz9jeziJru0vYuTkXDLBO17v-LKPu6TLK8" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+   (marmalade.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
    }])
 
 (expect "stat offer by running step 0 of sale"

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -2,7 +2,7 @@
 (load "../../policy-manager/policy-manager.repl")
 
 (begin-tx)
-(use kip.token-policy-v2 [concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+(use marmalade.policy-manager [concrete-policy concrete-policy])
 (use marmalade.ledger)
 
 (env-data {

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -4,8 +4,6 @@
 
 (interface poly-fungible-v3
 
-  (use kip.token-policy-v2 [token-policies])
-
   (defschema account-details
     @doc
       " Account details: token ID, account name, balance, and guard."
@@ -71,7 +69,7 @@
     @event
   )
 
-  (defcap TOKEN:bool (id:string precision:integer supply:decimal policies:object{token-policies} uri:string)
+  (defcap TOKEN:bool (id:string precision:integer supply:decimal policies:[module{kip.token-policy-v2}] uri:string)
     @doc " Emitted when token ID is created."
     @event
   )
@@ -182,7 +180,7 @@
     ( id:string
       precision:integer
       uri:string
-      policies:object{token-policies}
+      policies:[module{kip.token-policy-v2}]
     )
     @doc "Create a new token with ID, PRECISION, URI, and POLICY."
     @model

--- a/pact/kip/token-policy-v2.pact
+++ b/pact/kip/token-policy-v2.pact
@@ -89,14 +89,4 @@
          \ Also governs rotate of SENDER (with same RECEIVER and 0.0 AMOUNT). "
   )
 
-  (defun enforce-crosschain:bool
-    ( token:object{token-info}
-      sender:string
-      guard:guard
-      receiver:string
-      target-chain:string
-      amount:decimal )
-    @doc " Enforce rules on crosschain transfer of TOKEN AMOUNT \
-         \ from SENDER to RECEIVER on TARGET-CHAIN."
-  )
 )

--- a/pact/kip/token-policy-v2.pact
+++ b/pact/kip/token-policy-v2.pact
@@ -16,18 +16,12 @@
   (defconst COLLECTION_POLICY 'collection-policy )
   (defconst GUARD_POLICY 'guard-policy )
 
-  (defschema token-policies
-    concrete-policies:object{concrete-policy}
-    immutable-policies:[module{token-policy-v2}]
-    adjustable-policies:[module{token-policy-v2}]
-  )
-
   (defschema token-info
     id:string
     supply:decimal
     precision:integer
     uri:string
-    policies:object{token-policies})
+    policies:[module{token-policy-v2}])
 
   (defun enforce-mint:bool
     ( token:object{token-info}

--- a/pact/kip/token-policy-v2.pact
+++ b/pact/kip/token-policy-v2.pact
@@ -2,20 +2,6 @@
 
 (interface token-policy-v2
 
-  (defschema concrete-policy
-    non-fungible-policy:bool
-    quote-policy:bool
-    royalty-policy:bool
-    collection-policy:bool
-    guard-policy:bool
-  )
-
-  (defconst NON_FUNGIBLE_POLICY 'non-fungible-policy )
-  (defconst QUOTE_POLICY 'quote-policy )
-  (defconst ROYALTY_POLICY 'royalty-policy )
-  (defconst COLLECTION_POLICY 'collection-policy )
-  (defconst GUARD_POLICY 'guard-policy )
-
   (defschema token-info
     id:string
     supply:decimal

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -8,10 +8,10 @@
           (> (length account) 2))
     ]
 
-  (use util.fungible-util)
-  (use marmalade.policy-manager)
   (implements kip.poly-fungible-v3)
   (use kip.poly-fungible-v3 [account-details sender-balance-change receiver-balance-change])
+  (use util.fungible-util)
+  (use marmalade.policy-manager)
 
   ;;
   ;; Tables/Schemas
@@ -108,31 +108,6 @@
     @event
     true
   )
-
-
-  ; ;; dependent on marmalade
-  ; (defcap ADJUST_POLICY (token-id:string account:string)
-  ;   @event
-  ;   (enforce (= (get-balance token-id account) (total-supply token-id)) "Account doesn't own token")
-  ;   (enforce-guard (account-guard token-id account)))
-
-  ; (defun adjust-policy
-  ;   ( token-id:string
-  ;     account:string
-  ;     adjustable-policies:[module{kip.token-policy-v2}] )
-  ;   (with-capability (ADJUST_POLICY token-id account) ;; needs sigs from token owner
-  ;     (with-read tokens token-id {
-  ;       "policies":= old-policies
-  ;       }
-  ;       (let* ((new-policies:[module{kip.token-policy-v2}] (+
-  ;                 {'adjustable-policies: adjustable-policies}
-  ;                 old-policies
-  ;             )))
-  ;       (update tokens token-id {
-  ;         "policies": new-policies
-  ;       })
-  ;   ))
-  ; ))
 
   ;;
   ;; Implementation caps

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -203,7 +203,7 @@
     (with-capability (LEDGER)
       ;; enforces token and uri protocols
       (enforce-uri-reserved uri)
-      (let ((token-details { 'uri: uri, 'precision: precision, 'policies: policies }))
+      (let ((token-details { 'uri: uri, 'precision: precision, 'policies: (sort policies) }))
        (enforce-token-reserved id token-details)
       )
       ;; maps policy list and calls policy::enforce-init

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -3,7 +3,7 @@
 (module util-v1 GOVERNANCE
   (use kip.token-policy-v2)
   (use marmalade.policy-manager )
-  (use marmalade.policy-manager [concrete-policy NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+  (use marmalade.policy-manager [CONCRETE_POLICY_LIST NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
 
   (defschema concrete-policy-bool
     non-fungible-policy:bool
@@ -12,9 +12,6 @@
     collection-policy:bool
     guard-policy:bool
   )
-
-  (defconst CONCRETE_POLICY_LIST
-    [NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY] )
 
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -1,14 +1,25 @@
 (namespace (read-msg 'ns))
 
 (module util-v1 GOVERNANCE
-  (use kip.token-policy-v2 [ concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+  (use kip.token-policy-v2)
   (use marmalade.policy-manager )
+  (use marmalade.policy-manager [concrete-policy NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+
+  (defschema concrete-policy-bool
+    non-fungible-policy:bool
+    quote-policy:bool
+    royalty-policy:bool
+    collection-policy:bool
+    guard-policy:bool
+  )
+
+  (defconst CONCRETE_POLICY_LIST
+    [NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY] )
 
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
 
-
-  (defconst DEFAULT:object{concrete-policy}
+  (defconst DEFAULT:object{concrete-policy-bool}
     { 'quote-policy: true
      ,'non-fungible-policy: true
      ,'royalty-policy: false
@@ -16,7 +27,7 @@
      ,'guard-policy: true
      })
 
-  (defconst DEFAULT_ROYALTY:object{concrete-policy}
+  (defconst DEFAULT_ROYALTY:object{concrete-policy-bool}
     { 'quote-policy: true
      ,'non-fungible-policy: true
      ,'royalty-policy: true
@@ -25,7 +36,7 @@
     }
   )
 
-  (defconst DEFAULT_COLLECTION:object{concrete-policy}
+  (defconst DEFAULT_COLLECTION:object{concrete-policy-bool}
     { 'quote-policy: true
      ,'non-fungible-policy: true
      ,'royalty-policy: false
@@ -34,7 +45,7 @@
     }
   )
 
-  (defconst DEFAULT_COLLECTION_ROYALTY:object{concrete-policy}
+  (defconst DEFAULT_COLLECTION_ROYALTY:object{concrete-policy-bool}
     { 'quote-policy: true
      ,'non-fungible-policy: true
      ,'royalty-policy: true
@@ -43,7 +54,7 @@
     }
   )
 
-  (defconst EMPTY:object{concrete-policy}
+  (defconst EMPTY:object{concrete-policy-bool}
     { 'quote-policy: false
      ,'non-fungible-policy: false
      ,'royalty-policy: false
@@ -52,10 +63,18 @@
     }
   )
 
-  (defun create-policies (concrete-policy:object{concrete-policy})
+  (defun create-policies (concrete-policy:object{concrete-policy-bool})
     (let* ( (is-used-policy (lambda (policy-field:string) (at policy-field concrete-policy)))
             (used-policies:[string] (filter (is-used-policy) CONCRETE_POLICY_LIST)))
           (map (get-concrete-policy) used-policies))
   )
 
+  (defun create-concrete-policy:object{concrete-policy-bool} (policies:[module{kip.token-policy-v2}])
+    { 'quote-policy: (contains (get-concrete-policy QUOTE_POLICY) policies )
+     ,'non-fungible-policy: (contains (get-concrete-policy NON_FUNGIBLE_POLICY) policies)
+     ,'royalty-policy: (contains (get-concrete-policy ROYALTY_POLICY) policies)
+     ,'collection-policy: (contains (get-concrete-policy COLLECTION_POLICY) policies)
+     ,'guard-policy: (contains (get-concrete-policy GUARD_POLICY) policies)
+    }
+  )
 )

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -1,10 +1,11 @@
 (namespace (read-msg 'ns))
 
 (module util-v1 GOVERNANCE
-  (use kip.token-policy-v2 [token-policies concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+  (use kip.token-policy-v2 [ concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
 
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+
 
   (defconst DEFAULT:object{concrete-policy}
     { 'quote-policy: true
@@ -50,19 +51,4 @@
     }
   )
 
-  (defun create-default-policies:object{token-policies} (concrete-policies:object{concrete-policy})
-    {
-      'concrete-policies: concrete-policies
-     ,'immutable-policies: []
-     ,'adjustable-policies: []
-    }
-  )
-
-  (defun create-single-policy:object{token-policies} (policy:module{kip.token-policy-v2})
-    {
-      'concrete-policies: EMPTY
-     ,'immutable-policies: [policy]
-     ,'adjustable-policies: []
-    }
-  )
 )

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -2,6 +2,7 @@
 
 (module util-v1 GOVERNANCE
   (use kip.token-policy-v2 [ concrete-policy QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+  (use marmalade.policy-manager )
 
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
@@ -49,6 +50,12 @@
      ,'collection-policy:false
      ,'guard-policy: false
     }
+  )
+
+  (defun create-policies (concrete-policy:object{concrete-policy})
+    (let* ( (is-used-policy (lambda (policy-field:string) (at policy-field concrete-policy)))
+            (used-policies:[string] (filter (is-used-policy) CONCRETE_POLICY_LIST)))
+          (map (get-concrete-policy) used-policies))
   )
 
 )

--- a/pact/policy-manager/policy-manager.md
+++ b/pact/policy-manager/policy-manager.md
@@ -1,40 +1,30 @@
-
-
 # Policy Manager
 
 The Policy Manager is a module that enables token creators to define and enforce policies for their tokens. In contrast with marmalade v1 which only supports one policy marmalade v2 supports something we call `stackable-policies` which enables token creators to add multiple policies to their tokens. These policies can include rules for transfers, burns, sales, and more, providing a flexible and customisable way to manage the behaviour of tokens on the platform. The module is built using the `kip.token-policy-v2` interface, which defines the standard interface that token policies must implement.
 
-  
 This module includes the following key components:
-  
 
-**Concrete Policy List Schema**: The `concrete-policy-list` schema provides a structure for storing a list of concrete policies.
+**Ledger Info Table**: A table, `concrete-policy-table`, is created to store the concrete policy information for each token policy. This table ensures proper handling of policy configurations for the NFTs managed under the policy.
 
-**Concrete Policy Table**: A table, `concrete-policy-table`, is created to store the concrete policy information for each token policy. This table ensures proper handling of policy configurations for the NFTs managed under the policy.
+**Ledger Schema**: The `ledger` schema contains information about the ledger the policy manager manages for. It consists of `ledger`, `ledger-guard`, and `concrete-policy-manager` field.
 
-**Policies List Schema**: The `policies-list` schema provides a structure for storing three separate lists of policies: concrete, immutable, and adjustable. This allows for a clear separation of policies that can be modified and those that cannot be modified.
+**concrete-policy-manager Schema**: The `policies-list` schema provides a structure for storing three separate lists of policies: concrete, immutable, and adjustable. This allows for a clear separation of policies that can be modified and those that cannot be modified.
 
-
-  
 ## Policies List Schema
- Includes the following fields:
 
+Includes the following fields:
 
--  `concrete-policies`: A list of concrete policies.
-A Concrete policy can be viewed as a default policy provided by the marmalade team. Its a standardised set of policies to get token creators started.
-  
+- `concrete-policies`: A list of concrete policies.
+  A Concrete policy can be viewed as a default policy provided by the marmalade team. Its a standardised set of policies to get token creators started.
 
--  `immutable-policies`: A list of immutable policies.
-Immutable policies are policies that cannot be rotated
+<!-- * `immutable-policies`: A list of immutable policies.
+  Immutable policies are policies that cannot be rotated
 
-  
--  `adjustable-policies`: A list of adjustable policies.
-Adjustable policies are policies that can be rotated
-
-   
+- `adjustable-policies`: A list of adjustable policies.
+  Adjustable policies are policies that can be rotated -->
 
 ## Policy Functions
-  
+
 `enforce-buy`: The `enforce-buy` function first calls the `enforce-ledger` function to ensure the ledger is up-to-date. It then retrieves the `policies` object from the `token` input parameter, which contains a list of policies associated with the token.
 
 Its good to understand that the buy function within the policy manager acts a bit different then your regular policy, since it's managing other policies. In this case it checks
@@ -44,23 +34,19 @@ If the `QUOTE_POLICY` is not present in the policies list, the function continue
 
 Regardless of whether the `QUOTE_POLICY` is present, the function then iterates over the list of policies (excluding the `QUOTE_POLICY`) and enforce-buy on each policy within the list.
 
-  
-`is-used`:  Is a simple helper function we created to indicate whether a specific policy is currently in use for the token.
+`is-used`: Is a simple helper function we created to indicate whether a specific policy is currently in use for the token.
 
-`get-escrow-account`:  TODO
+`get-escrow-account`: Returns the escrow account created in `bidding` inside quote policy, which received funds when the bidder initiated the bid.
 
-
-`enforce-sale-pact`: Ensures that the `sale` parameter provided to the function is equal to the ID of the currently executing pact. It does this by calling the `pact-id` function to retrieve the ID of the currently executing pact and comparing it to the provided `sale` parameter. If they are not equal, an exception will be thrown". 
+`enforce-sale-pact`: Ensures that the `sale` parameter provided to the function is equal to the ID of the currently executing pact. It does this by calling the `pact-id` function to retrieve the ID of the currently executing pact and comparing it to the provided `sale` parameter. If they are not equal, an exception will be thrown".
 
 `create-concrete-policy-list`: We use this to generate a list of concrete policies from the available policies stored in a `token-policies` object.
 
-## Events
+<!-- ## Events
 
- 
 #### `ROTATE_POLICY` Event
-  
+
 The `ROTATE_POLICY` event is emitted when a new policy is set for a token ID in the `concrete-policy-table` within the `policy-manager` module. The primary purpose of this event is to log and provide information about the token and the updated policy.
 
 This event is emitted using the following line of code:
-`(emit-event (ROTATE_POLICY token-id policy))`
-
+`(emit-event (ROTATE_POLICY token-id policy))` -->

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -192,12 +192,13 @@
   )
 
   (defun create-concrete-policy:object{concrete-policy} (policies:[module{kip.token-policy-v2}])
-    { 'quote-policy: (is-used policies QUOTE_POLICY)
-     ,'non-fungible-policy: (is-used policies NON_FUNGIBLE_POLICY)
-     ,'royalty-policy: (is-used policies ROYALTY_POLICY)
-     ,'collection-policy: (is-used policies COLLECTION_POLICY)
-     ,'guard-policy: (is-used policies GUARD_POLICY)
-     }
+    (let ((registered-policies:object{concrete-policy-manager} (get-concrete-policies (get-ledger-info))))
+      { 'quote-policy: (contains (at QUOTE_POLICY registered-policies) policies )
+       ,'non-fungible-policy: (contains (at NON_FUNGIBLE_POLICY registered-policies) policies)
+       ,'royalty-policy: (contains (at ROYALTY_POLICY registered-policies) policies)
+       ,'collection-policy: (contains (at COLLECTION_POLICY registered-policies) policies)
+       ,'guard-policy: (contains (at GUARD_POLICY registered-policies) policies)
+      })
   )
 
   (defun create-policies (concrete-policy:object{concrete-policy})

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -171,17 +171,6 @@
     (let ((policies:[module{kip.token-policy-v2}]  (at 'policies token)))
       (map-transfer token sender guard receiver amount policies)))
 
-  (defun enforce-crosschain:[bool]
-    ( token:object{token-info}
-      sender:string
-      guard:guard
-      receiver:string
-      target-chain:string
-      amount:decimal )
-    (enforce-ledger)
-    (let ((policies:[module{kip.token-policy-v2}]  (at 'policies token)))
-      (map-crosschain token sender guard receiver target-chain amount policies)))
-
   (defun enforce-withdraw:[bool]
     ( token:object{token-info}
       seller:string
@@ -249,12 +238,6 @@
 
    (defun map-transfer (token:object{token-info} sender:string guard:guard receiver:string amount:decimal policy-list:[module{kip.token-policy-v2}])
      (map (token-transfer  token sender guard receiver amount) policy-list))
-
-   (defun token-crosschain (token:object{token-info} sender:string guard:guard receiver:string target-chain:string amount:decimal policy:module{kip.token-policy-v2})
-     (policy::enforce-crosschain  token sender guard receiver target-chain amount))
-
-   (defun map-crosschain (token:object{token-info} params:object sender:string guard:guard receiver:string target-chain:string amount:decimal policy-list:[module{kip.token-policy-v2}])
-     (map (token-crosschain  token sender guard receiver target-chain amount) policy-list))
 )
 
 (if (read-msg 'upgrade )

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -1,15 +1,12 @@
-
 (namespace (read-msg 'ns))
 
 (module policy-manager GOVERNANCE
+
   (defcap GOVERNANCE ()
     (enforce-guard 'marmalade-admin ))
 
   ; (implements kip.token-policy-v2)
-  (use kip.token-policy-v2 [ token-info concrete-policy NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
-
-  (defconst CONCRETE_POLICY_V1_LIST
-    [NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY] )
+  (use kip.token-policy-v2 [token-info concrete-policy NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
 
   ;; schema to save policy list in table
   (defschema concrete-policy-manager
@@ -20,32 +17,28 @@
     guard-policy:module{kip.token-policy-v2}
   )
 
-  ;; used in the filter
-  (defconst CONCRETE_POLICY_LIST
-    [NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY] )
-
-
-  (defschema ledger
-    ledger:module{kip.poly-fungible-v3} ;; marmalade.ledger
-    guard:guard  ;;marmalade-ledger guard
-    ;; ledger vs guard
-    concrete-policies:object{concrete-policy-manager} ;; module ref to concrete-policies
+  (defschema ledger ;; rename to ledger-info
+    ledger:module{kip.poly-fungible-v3}
+    ledger-guard:guard
+    concrete-policies:object{concrete-policy-manager}
   )
 
   (deftable ledgers:{ledger})
 
-  (defun enforce-ledger:bool ()
-    ;;dependency issue
-    (enforce-guard (get-ledger-guard (get-ledger-info)))
-  )
+  ;; used in the filter
+  (defconst CONCRETE_POLICY_LIST
+    [NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY] )
 
   (defcap ADMIN ()
-    ;;add admin check
     (enforce-guard 'marmalade-admin)
   )
 
   (defcap QUOTE_ESCROW (sale-id:string)
     true
+  )
+
+  (defun enforce-ledger:bool ()
+    (enforce-guard (get-ledger-guard (get-ledger-info)))
   )
 
   (defun init:bool(ledger-info:object{ledger})
@@ -55,36 +48,18 @@
     true
   )
 
-  (defun get-concrete-policy:module{kip.token-policy-v2} (policy-field:string)
-    (at policy-field (get-concrete-policies (get-ledger-info)))
-  )
-
-  (defun get-concrete-policies:object{concrete-policy-manager} (ledger:object{ledger})
-    (at 'concrete-policies ledger)
-  )
-
-  (defun get-ledger-guard:guard (ledger:object{ledger})
-    (at 'guard ledger)
-  )
-
-  (defun get-ledger-contract:module{kip.poly-fungible-v3} (ledger:object{ledger})
-    (at 'ledger ledger)
-  )
-
   (defun get-ledger-info:object{ledger} ()
-    (read ledgers "") ;; default to ""
-  )
-
-  (defun enforce-init:[bool] (token:object{token-info})
-    (enforce-ledger)
-    (map-init token (at 'policies token))
+    (read ledgers "")
   )
 
   (defun is-used:bool (policies:[module{kip.token-policy-v2}] policy:string)
     (contains (get-concrete-policy policy) policies)
   )
 
-
+  (defun enforce-init:[bool] (token:object{token-info})
+    (enforce-ledger)
+    (map-init token (at 'policies token))
+  )
 
   (defun enforce-mint:[bool]
     ( token:object{token-info}
@@ -111,9 +86,20 @@
       amount:decimal
       sale-id:string )
     (enforce-ledger)
+    (enforce-sale-pact sale-id)
     (let ((policies:[module{kip.token-policy-v2}]  (at 'policies token)))
       (map-offer token seller amount sale-id policies)))
-;;[bool]
+
+  (defun enforce-withdraw:[bool]
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      sale-id:string )
+    (enforce-ledger)
+    (enforce-sale-pact sale-id)
+    (let ((policies:[module{kip.token-policy-v2}]  (at 'policies token)))
+      (map-withdraw token seller amount sale-id policies)))
+
   (defun enforce-buy:bool
     ( token:object{token-info}
       seller:string
@@ -122,10 +108,11 @@
       amount:decimal
       sale-id:string )
     (enforce-ledger)
+    (enforce-sale-pact sale-id)
     (let ((policies:[module{kip.token-policy-v2}]  (at 'policies token))
           (quote-policy:module{kip.token-policy-v2, marmalade.fungible-quote-policy-interface-v1} (get-concrete-policy QUOTE_POLICY)))
       (if (is-used policies QUOTE_POLICY)
-        ;; enforce-buy when quote policy is used
+        ;; quote policy is used
         (let* ((quote:object{marmalade.fungible-quote-policy-interface-v1.quote-schema} (quote-policy::get-quote sale-id))
                (spec:object{marmalade.fungible-quote-policy-interface-v1.quote-spec} (at 'spec quote))
                (fungible:module{fungible-v2} (at 'fungible spec))
@@ -141,25 +128,15 @@
             (quote-policy::accept-bid bid-id buyer sale-id escrow-account escrow-guard)
           )
 
-           (map-buy token seller buyer buyer-guard amount sale-id
-              (filter (!= quote-policy) policies))
-              (quote-policy::enforce-buy token seller buyer buyer-guard amount sale-id)
-          ))
+         (map-buy token seller buyer buyer-guard amount sale-id
+            (filter (!= quote-policy) policies))
+            (quote-policy::enforce-buy token seller buyer buyer-guard amount sale-id)
+        ))
 
-        ;; enforce-buy without the use of quote policy
+        ;; quote policy is not used
         (map-buy token seller buyer buyer-guard amount sale-id policies)
       )
     ))
-
-    (defun get-escrow-account (sale-id:string)
-      { 'account: (create-principal (create-capability-guard (QUOTE_ESCROW sale-id)))
-      , 'guard: (create-capability-guard (QUOTE_ESCROW sale-id))
-      })
-
-    (defun enforce-sale-pact:bool (sale:string)
-      "Enforces that SALE is id for currently executing pact"
-      (enforce (= sale (pact-id)) "Invalid pact/sale id")
-    )
 
   (defun enforce-transfer:[bool]
     ( token:object{token-info}
@@ -171,14 +148,17 @@
     (let ((policies:[module{kip.token-policy-v2}]  (at 'policies token)))
       (map-transfer token sender guard receiver amount policies)))
 
-  (defun enforce-withdraw:[bool]
-    ( token:object{token-info}
-      seller:string
-      amount:decimal
-      sale-id:string )
-    ;;TODO
-    true
+;; Sale/Escrow Functions
+  (defun get-escrow-account (sale-id:string)
+    { 'account: (create-principal (create-capability-guard (QUOTE_ESCROW sale-id)))
+    , 'guard: (create-capability-guard (QUOTE_ESCROW sale-id))
+    })
+
+  (defun enforce-sale-pact:bool (sale:string)
+    "Enforces that SALE is id for currently executing pact"
+    (enforce (= sale (pact-id)) "Invalid pact/sale id")
   )
+
 
   (defun create-concrete-policy:object{concrete-policy} (policies:[module{kip.token-policy-v2}])
     (let ((registered-policies:object{concrete-policy-manager} (get-concrete-policies (get-ledger-info))))
@@ -190,54 +170,66 @@
       })
   )
 
-  (defun create-policies (concrete-policy:object{concrete-policy})
-    (let* ( (is-used-policy (lambda (policy-field:string) (at policy-field concrete-policy)))
-            (used-policies:[string] (filter (is-used-policy) CONCRETE_POLICY_LIST)))
-          (map (get-concrete-policy) used-policies))
+  ;;utility functions to get ledger-info
+  (defun get-concrete-policy:module{kip.token-policy-v2} (policy-field:string)
+    (at policy-field (get-concrete-policies (get-ledger-info)))
   )
 
-  ; (defun mint-guard ()
-  ;   (if (is-used guard-policy)
-  ;     (guard-policy.get-mint-guard)
-  ;   )
-  ; )
+  (defun get-concrete-policies:object{concrete-policy-manager} (ledger:object{ledger})
+    (at 'concrete-policies ledger)
+  )
 
-   ;;utility functions to map policy list
-   (defun token-init (token:object{token-info} policy:module{kip.token-policy-v2})
-     (policy::enforce-init token))
+  (defun get-ledger-guard:guard (ledger:object{ledger})
+    (at 'ledger-guard ledger)
+  )
 
-   (defun map-init (token:object{token-info} policy-list:[module{kip.token-policy-v2}])
-     (map (token-init token) policy-list))
+  (defun get-ledger-contract:module{kip.poly-fungible-v3} (ledger:object{ledger})
+    (at 'ledger ledger)
+  )
 
-   (defun token-mint (token:object{token-info} account:string guard:guard amount:decimal policy:module{kip.token-policy-v2})
-     (policy::enforce-mint token account guard amount))
+  ;;utility functions to map policies
+ (defun token-init (token:object{token-info} policy:module{kip.token-policy-v2})
+  (policy::enforce-init token))
 
-   (defun map-mint (token:object{token-info} account:string guard:guard amount:decimal policy-list:[module{kip.token-policy-v2}])
-     (map (token-mint token account guard amount) policy-list))
+ (defun map-init (token:object{token-info} policy-list:[module{kip.token-policy-v2}])
+  (map (token-init token) policy-list))
 
-   (defun token-offer (token:object{token-info} account:string amount:decimal sale-id:string policy:module{kip.token-policy-v2})
-     (policy::enforce-offer token account amount sale-id))
+ (defun token-mint (token:object{token-info} account:string guard:guard amount:decimal policy:module{kip.token-policy-v2})
+  (policy::enforce-mint token account guard amount))
 
-   (defun map-offer (token:object{token-info} account:string amount:decimal sale-id:string policy-list:[module{kip.token-policy-v2}])
-     (map (token-offer token account amount sale-id) policy-list))
+ (defun map-mint (token:object{token-info} account:string guard:guard amount:decimal policy-list:[module{kip.token-policy-v2}])
+  (map (token-mint token account guard amount) policy-list))
 
-   (defun token-burn (token:object{token-info} account:string amount:decimal policy:module{kip.token-policy-v2})
-     (policy::enforce-burn token account amount))
+ (defun token-burn (token:object{token-info} account:string amount:decimal policy:module{kip.token-policy-v2})
+  (policy::enforce-burn token account amount))
 
-   (defun map-burn (token:object{token-info} account:string amount:decimal policy-list:[module{kip.token-policy-v2}])
-     (map (token-burn token account amount) policy-list))
+ (defun map-burn (token:object{token-info} account:string amount:decimal policy-list:[module{kip.token-policy-v2}])
+  (map (token-burn token account amount) policy-list))
 
-   (defun token-buy (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string policy:module{kip.token-policy-v2})
-     (policy::enforce-buy token seller buyer buyer-guard amount sale-id))
+ (defun token-offer (token:object{token-info} account:string amount:decimal sale-id:string policy:module{kip.token-policy-v2})
+  (policy::enforce-offer token account amount sale-id))
 
-   (defun map-buy:[bool] (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string policy-list:[module{kip.token-policy-v2}])
-     (map (token-buy token seller buyer buyer-guard amount sale-id) policy-list))
+ (defun map-offer (token:object{token-info} account:string amount:decimal sale-id:string policy-list:[module{kip.token-policy-v2}])
+  (map (token-offer token account amount sale-id) policy-list))
 
-   (defun token-transfer (token:object{token-info} sender:string guard:guard receiver:string amount:decimal policy:module{kip.token-policy-v2})
-     (policy::enforce-transfer  token sender guard receiver amount))
+  (defun token-withdraw (token:object{token-info} account:string amount:decimal sale-id:string policy:module{kip.token-policy-v2})
+   (policy::enforce-withdraw token account amount sale-id))
 
-   (defun map-transfer (token:object{token-info} sender:string guard:guard receiver:string amount:decimal policy-list:[module{kip.token-policy-v2}])
-     (map (token-transfer  token sender guard receiver amount) policy-list))
+  (defun map-withdraw (token:object{token-info} account:string amount:decimal sale-id:string policy-list:[module{kip.token-policy-v2}])
+   (map (token-withdraw token account amount sale-id) policy-list))
+
+ (defun token-buy (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string policy:module{kip.token-policy-v2})
+  (policy::enforce-buy token seller buyer buyer-guard amount sale-id))
+
+ (defun map-buy:[bool] (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string policy-list:[module{kip.token-policy-v2}])
+  (map (token-buy token seller buyer buyer-guard amount sale-id) policy-list))
+
+ (defun token-transfer (token:object{token-info} sender:string guard:guard receiver:string amount:decimal policy:module{kip.token-policy-v2})
+  (policy::enforce-transfer  token sender guard receiver amount))
+
+ (defun map-transfer (token:object{token-info} sender:string guard:guard receiver:string amount:decimal policy-list:[module{kip.token-policy-v2}])
+  (map (token-transfer  token sender guard receiver amount) policy-list))
+
 )
 
 (if (read-msg 'upgrade )

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -8,6 +8,9 @@
   ; (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info ])
 
+  (defconst CONCRETE_POLICY_LIST
+    [NON_FUNGIBLE_POLICY QUOTE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY] )
+
   (defconst NON_FUNGIBLE_POLICY 'non-fungible-policy )
   (defconst QUOTE_POLICY 'quote-policy )
   (defconst ROYALTY_POLICY 'royalty-policy )
@@ -160,6 +163,7 @@
 
 
   (defun add-concrete-policy:bool (policy-field:string policy:module{kip.token-policy-v2})
+    (contains policy-field CONCRETE_POLICY_LIST)
     (with-capability (ADMIN)
       (insert concrete-policies policy-field {
         "policy": policy
@@ -169,6 +173,7 @@
   )
 
   (defun update-concrete-policy:bool (policy-field:string policy:module{kip.token-policy-v2})
+    (contains policy-field CONCRETE_POLICY_LIST)
     (with-capability (ADMIN)
       (update concrete-policies policy-field {
         "policy": policy

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -17,7 +17,7 @@
   (defconst COLLECTION_POLICY 'collection-policy )
   (defconst GUARD_POLICY 'guard-policy )
 
-  (defschema ledger ;; rename to ledger-info
+  (defschema ledger 
     ledger:module{kip.poly-fungible-v3}
     ledger-guard:guard
   )

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -60,18 +60,16 @@
   (load "../concrete-policies/collection-policy/collection-policy-v1.pact")
   (load "../concrete-policies/guard-policy/guard-policy-v1.pact")
 
-  (use kip.token-policy-v2 [QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+  (use marmalade.policy-manager [QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
   (marmalade.policy-manager.init {
-    "concrete-policies": {
-      'non-fungible-policy:marmalade.non-fungible-policy-v1
-      ,'quote-policy:marmalade.fungible-quote-policy-v1
-      ,'royalty-policy:marmalade.royalty-policy-v1
-      ,'collection-policy:marmalade.collection-policy-v1
-      ,'guard-policy:marmalade.guard-policy-v1
-      }
-    ,"ledger-guard": (marmalade.ledger.ledger-guard)
+     "ledger-guard": (marmalade.ledger.ledger-guard)
     ,"ledger": marmalade.ledger
   })
+  (marmalade.policy-manager.add-concrete-policy QUOTE_POLICY marmalade.fungible-quote-policy-v1)
+  (marmalade.policy-manager.add-concrete-policy NON_FUNGIBLE_POLICY marmalade.non-fungible-policy-v1)
+  (marmalade.policy-manager.add-concrete-policy ROYALTY_POLICY marmalade.royalty-policy-v1)
+  (marmalade.policy-manager.add-concrete-policy COLLECTION_POLICY marmalade.collection-policy-v1)
+  (marmalade.policy-manager.add-concrete-policy GUARD_POLICY marmalade.guard-policy-v1)
 
 (commit-tx)
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -23,8 +23,6 @@
   (load "../kip/token-policy-v2.pact")
   (load "../kip/poly-fungible-v2.pact")
   (load "../kip/poly-fungible-v3.pact")
-
-
   (define-namespace 'util (sig-keyset) (sig-keyset))
   (load "../util/fungible-util.pact")
 (commit-tx)
@@ -47,6 +45,7 @@
    , 'marmalade-ns-admin: ["marmalade-admin"]
    , 'ns: "marmalade"
    , 'upgrade: false })
+
   (load "../concrete-policies/fungible-quote-policy/fungible-quote-policy-interface-v1.pact")
   (load "../policy-manager/policy-manager.pact")
   (load "../ledger.pact")
@@ -70,7 +69,7 @@
       ,'collection-policy:marmalade.collection-policy-v1
       ,'guard-policy:marmalade.guard-policy-v1
       }
-    ,"guard": (marmalade.ledger.ledger-guard)
+    ,"ledger-guard": (marmalade.ledger.ledger-guard)
     ,"ledger": marmalade.ledger
   })
 
@@ -124,7 +123,6 @@
 (expect "create a token with no concrete-policy"
   true
   (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-policies EMPTY) ))
-
 (expect "mint a default token with quote-policy, non-fungible-policy"
   true
   (mint (read-msg 'default-token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -61,14 +61,18 @@
   (load "../concrete-policies/collection-policy/collection-policy-v1.pact")
   (load "../concrete-policies/guard-policy/guard-policy-v1.pact")
 
-
   (use kip.token-policy-v2 [QUOTE_POLICY NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
-  (marmalade.policy-manager.init (marmalade.ledger.ledger-guard))
-  (marmalade.policy-manager.add-concrete-policy QUOTE_POLICY marmalade.fungible-quote-policy-v1)
-  (marmalade.policy-manager.add-concrete-policy NON_FUNGIBLE_POLICY marmalade.non-fungible-policy-v1)
-  (marmalade.policy-manager.add-concrete-policy ROYALTY_POLICY marmalade.royalty-policy-v1)
-  (marmalade.policy-manager.add-concrete-policy COLLECTION_POLICY marmalade.collection-policy-v1)
-  (marmalade.policy-manager.add-concrete-policy GUARD_POLICY marmalade.guard-policy-v1)
+  (marmalade.policy-manager.init {
+    "concrete-policies": {
+      'non-fungible-policy:marmalade.non-fungible-policy-v1
+      ,'quote-policy:marmalade.fungible-quote-policy-v1
+      ,'royalty-policy:marmalade.royalty-policy-v1
+      ,'collection-policy:marmalade.collection-policy-v1
+      ,'guard-policy:marmalade.guard-policy-v1
+      }
+    ,"guard": (marmalade.ledger.ledger-guard)
+    ,"ledger": marmalade.ledger
+  })
 
 (commit-tx)
 
@@ -86,9 +90,9 @@
 (use marmalade.util-v1)
 
 (env-data {
-  "default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-default-policies DEFAULT) } )
- ,"reserved-token-id": (create-token-id { 'uri: "marmalade-uri", 'precision: 0, 'policies: (create-default-policies DEFAULT) } )
- ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-default-policies EMPTY) } )
+  "default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+ ,"reserved-token-id": (create-token-id { 'uri: "marmalade-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+ ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-policies EMPTY) } )
  ,"wrong-token-protocol-id": "t:wrong"
  ,"wrong-token-id": "wrong"
  ,"account": "k:account"
@@ -96,30 +100,30 @@
   })
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade.ledger.MINT "t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "k:account" 1.0)
-            (marmalade.ledger.MINT "t:6ll2WfFkYk7Pi6oZiFlpRLC7VadDLg50f9Ref4oA54Y" "k:account" 1.0)
+   ,'caps: [(marmalade.ledger.MINT "t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0)
+            (marmalade.ledger.MINT "t:mXoVZ-STyWr5aAyVXpgjRAkD5Cpgs33pG7mVQiftTrk" "k:account" 1.0)
    ]
    }])
 
 (expect-failure "create a token with uri starting with marmalade fails"
   "Reserved protocol: marmalade"
-  (create-token (read-msg 'reserved-token-id) 0 "marmalade-uri" (create-default-policies DEFAULT) ))
+  (create-token (read-msg 'reserved-token-id) 0 "marmalade-uri" (create-policies DEFAULT) ))
 
 (expect-failure "create a token with unmatching token-id"
   "Token protocol violation"
-  (create-token (read-msg 'wrong-token-protocol-id) 0 "test-uri" (create-default-policies DEFAULT) ))
+  (create-token (read-msg 'wrong-token-protocol-id) 0 "test-uri" (create-policies DEFAULT) ))
 
 (expect-failure "create a token without token protocol"
   "Unrecognized reserved protocol"
-  (create-token (read-msg 'wrong-token-id) 0 "test-uri" (create-default-policies DEFAULT) ))
+  (create-token (read-msg 'wrong-token-id) 0 "test-uri" (create-policies DEFAULT) ))
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-default-policies DEFAULT) ))
+  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-policies DEFAULT) ))
 
 (expect "create a token with no concrete-policy"
   true
-  (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-default-policies EMPTY) ))
+  (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-policies EMPTY) ))
 
 (expect "mint a default token with quote-policy, non-fungible-policy"
   true
@@ -134,6 +138,7 @@
 (begin-tx "start an offer")
   (env-hash (hash "offer-0"))
   (use marmalade.ledger)
+  (use marmalade.policy-manager)
   (use marmalade.util-v1)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -141,7 +146,7 @@
   (marmalade.abc.create-account "k:account" (read-keyset 'seller-guard))
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-default-policies DEFAULT) } )
+    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
   ,"quote": {
     "fungible": marmalade.abc
     ,"price": 2.0
@@ -153,22 +158,23 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-    (marmalade.ledger.OFFER "t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+    (marmalade.ledger.OFFER "t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
     }])
+
   (expect "stat offer by running step 0 of sale"
     true
     (sale (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z")))
 
   (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}})
 
-  (expect "events"
+  (expect "events" 
     (format "{}" [[
-      {"name": "marmalade.ledger.OFFER","params": ["t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "k:account" 1.0 "2023-07-22T11:26:35Z"]}
-      {"name": "marmalade.ledger.SALE","params": ["t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-      {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" 1.0 2.0 2.0 {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
-      {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
-      {"name": "marmalade.ledger.TRANSFER","params": ["t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
-      {"name": "marmalade.ledger.RECONCILE","params": ["t:jEkXrh56WxrSF73Vpq5nVlAp9N9EIU8VXPJKaJegGc4" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
+      {"name": "marmalade.ledger.OFFER","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0 "2023-07-22T11:26:35Z"]}
+      {"name": "marmalade.ledger.SALE","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" 1.0 2.0 2.0 {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
+      {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
+      {"name": "marmalade.ledger.TRANSFER","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
+      {"name": "marmalade.ledger.RECONCILE","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
     (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 
@@ -187,7 +193,7 @@
   (env-sigs
   [{'key:'buyer
     ,'caps: [
-      (BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-default-policies DEFAULT) } ) "k:account" "k:buyer" 1.0 (time "2023-07-22T11:26:35Z") "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
+      (BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } ) "k:account" "k:buyer" 1.0 (time "2023-07-22T11:26:35Z") "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
       (marmalade.abc.TRANSFER "k:buyer" "c:A2ZV26b7mo4xXNBvkwvG8jeeLPyKUc3mGDrjo9rv9WI" 2.0)
 
     ]}])
@@ -221,7 +227,7 @@
     "token-id": (create-token-id {
       'uri: "test-quote-royalty-uri",
       'precision: 0,
-      'policies: (create-default-policies {
+      'policies: (create-policies {
         'quote-policy: true
         ,'non-fungible-policy: false
         ,'royalty-policy: true
@@ -246,7 +252,7 @@
 
   (expect "create a token with quote-policy and royalty-policy"
     true
-    (create-token (read-msg 'token-id) 0 "test-quote-royalty-uri" (create-default-policies {
+    (create-token (read-msg 'token-id) 0 "test-quote-royalty-uri" (create-policies {
       'quote-policy: true
       ,'non-fungible-policy: false
       ,'royalty-policy: true
@@ -257,7 +263,7 @@
   (env-sigs [
     { 'key: 'seller
     ,'caps: [
-    (marmalade.ledger.MINT "t:FOPgAhfprDFexl8kS89KO9iXLWkecDk9Z8xs1ki2ksw" "k:account" 1.0)]
+    (marmalade.ledger.MINT "t:Roq0Ipvygt1meBEZvQKGWv2-QICD8UYOkI76rPS6P2s" "k:account" 1.0)]
   }])
 
   (expect "mint 1.0 amount "
@@ -279,7 +285,7 @@
     "token-id": (create-token-id {
       'uri: "test-quote-royalty-uri",
       'precision: 0,
-      'policies: (create-default-policies {
+      'policies: (create-policies {
         'quote-policy: true
         ,'non-fungible-policy: false
         ,'royalty-policy: true
@@ -314,7 +320,7 @@
     "token-id": (create-token-id {
       'uri: "test-quote-royalty-uri",
       'precision: 0,
-      'policies: (create-default-policies {
+      'policies: (create-policies {
         'quote-policy: true
         ,'non-fungible-policy: false
         ,'royalty-policy: true

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -99,7 +99,7 @@
   })
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade.ledger.MINT "t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0)
+   ,'caps: [(marmalade.ledger.MINT "t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" 1.0)
             (marmalade.ledger.MINT "t:mXoVZ-STyWr5aAyVXpgjRAkD5Cpgs33pG7mVQiftTrk" "k:account" 1.0)
    ]
    }])
@@ -123,6 +123,7 @@
 (expect "create a token with no concrete-policy"
   true
   (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-policies EMPTY) ))
+
 (expect "mint a default token with quote-policy, non-fungible-policy"
   true
   (mint (read-msg 'default-token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))
@@ -156,7 +157,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-    (marmalade.ledger.OFFER "t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+    (marmalade.ledger.OFFER "t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
     }])
 
   (expect "stat offer by running step 0 of sale"
@@ -167,12 +168,12 @@
 
   (expect "events"
     (format "{}" [[
-      {"name": "marmalade.ledger.OFFER","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0 "2023-07-22T11:26:35Z"]}
-      {"name": "marmalade.ledger.SALE","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-      {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" 1.0 2.0 2.0 {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
-      {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
-      {"name": "marmalade.ledger.TRANSFER","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
-      {"name": "marmalade.ledger.RECONCILE","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
+      {"name": "marmalade.ledger.OFFER","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" 1.0 "2023-07-22T11:26:35Z"]}
+      {"name": "marmalade.ledger.SALE","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" 1.0 2.0 2.0 {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
+      {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
+      {"name": "marmalade.ledger.TRANSFER","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
+      {"name": "marmalade.ledger.RECONCILE","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
     (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 
@@ -261,7 +262,7 @@
   (env-sigs [
     { 'key: 'seller
     ,'caps: [
-    (marmalade.ledger.MINT "t:Roq0Ipvygt1meBEZvQKGWv2-QICD8UYOkI76rPS6P2s" "k:account" 1.0)]
+    (marmalade.ledger.MINT "t:SpPjVGeY6S4JEMRyokN2qATtslFHN91hEmzNGrw-ViA" "k:account" 1.0)]
   }])
 
   (expect "mint 1.0 amount "

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -95,6 +95,7 @@
  ,"account": "k:account"
  ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
   })
+
 (env-sigs [
   { 'key: 'account
    ,'caps: [(marmalade.ledger.MINT (read-msg "default-token-id") "k:account" 1.0)
@@ -130,7 +131,113 @@
   true
   (mint (read-msg 'empty-token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))
 
+(env-sigs [
+  { 'key: 'marmalade-admin
+   ,'caps: []
+   }])
+
 (commit-tx)
+
+
+(begin-tx)
+(env-sigs [
+  { 'key: 'marmalade-admin
+   ,'caps: []
+   }])
+(env-data {
+  "ns": "marmalade"
+  })
+  (namespace 'marmalade)
+  (namespace (read-msg 'ns))
+
+  (module non-fungible-policy-v1 GOVERNANCE
+
+    @doc "Concrete policy for issuing an nft with a fixed supply of 1"
+
+    (defcap GOVERNANCE ()
+      (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+
+    (implements kip.token-policy-v2)
+    (use kip.token-policy-v2 [token-info])
+
+    (defun enforce-ledger:bool ()
+       (enforce-guard (marmalade.ledger.ledger-guard))
+    )
+
+    (defun enforce-init:bool
+      ( token:object{token-info}
+      )
+      (enforce-ledger)
+      true
+    )
+
+    (defun enforce-mint:bool
+      ( token:object{token-info}
+        account:string
+        guard:guard
+        amount:decimal
+      )
+      (enforce-ledger)
+    )
+
+    (defun enforce-burn:bool
+      ( token:object{token-info}
+        account:string
+        amount:decimal
+      )
+      (enforce-ledger)
+    )
+
+    (defun enforce-offer:bool
+      ( token:object{token-info}
+        seller:string
+        amount:decimal
+        sale-id:string
+      )
+      @doc "Capture quote spec for SALE of TOKEN from message"
+      (enforce-ledger)
+    )
+
+    (defun enforce-buy:bool
+      ( token:object{token-info}
+        seller:string
+        buyer:string
+        buyer-guard:guard
+        amount:decimal
+        sale-id:string )
+      (enforce-ledger)
+    )
+
+    (defun enforce-transfer:bool
+      ( token:object{token-info}
+        sender:string
+        guard:guard
+        receiver:string
+        amount:decimal )
+      (enforce-ledger)
+    )
+
+    (defun enforce-withdraw:bool
+      ( token:object{token-info}
+        seller:string
+        amount:decimal
+        sale-id:string )
+      (enforce-ledger)
+    )
+  )
+
+  (use marmalade.policy-manager)
+  (use marmalade.policy-manager [NON_FUNGIBLE_POLICY])
+  (use marmalade.util-v1)
+  (use marmalade.ledger)
+  (expect "upgrade non-fungible-policy"
+    true
+    (update-concrete-policy NON_FUNGIBLE_POLICY marmalade.non-fungible-policy-v1))
+  (expect "check if stored policy matches with saved concrete-policy"
+    true
+    (is-used (at 'policies (get-token-info "t:9BJQ9Qyqfq4pmDGC18xjAao3ZclVz3jFATq2LBBgIpQ")) NON_FUNGIBLE_POLICY))
+
+(rollback-tx)
 
 (begin-tx "start an offer")
   (env-hash (hash "offer-0"))

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -99,8 +99,8 @@
   })
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade.ledger.MINT "t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" 1.0)
-            (marmalade.ledger.MINT "t:mXoVZ-STyWr5aAyVXpgjRAkD5Cpgs33pG7mVQiftTrk" "k:account" 1.0)
+   ,'caps: [(marmalade.ledger.MINT (read-msg "default-token-id") "k:account" 1.0)
+            (marmalade.ledger.MINT (read-msg 'empty-token-id) "k:account" 1.0)
    ]
    }])
 
@@ -146,7 +146,7 @@
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
-  ,"quote": {
+   ,"quote": {
     "fungible": marmalade.abc
     ,"price": 2.0
     ,"amount": 1.0
@@ -157,23 +157,26 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-    (marmalade.ledger.OFFER "t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+    (marmalade.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
     }])
 
   (expect "stat offer by running step 0 of sale"
     true
     (sale (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z")))
 
-  (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}})
+  (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}
+            , "token-id" : (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+}
+  )
 
   (expect "events"
     (format "{}" [[
-      {"name": "marmalade.ledger.OFFER","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" 1.0 "2023-07-22T11:26:35Z"]}
-      {"name": "marmalade.ledger.SALE","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-      {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" 1.0 2.0 2.0 {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
-      {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
-      {"name": "marmalade.ledger.TRANSFER","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
-      {"name": "marmalade.ledger.RECONCILE","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
+      {"name": "marmalade.ledger.OFFER","params": [(read-msg 'token-id) "k:account" 1.0 "2023-07-22T11:26:35Z"]}
+      {"name": "marmalade.ledger.SALE","params": [(read-msg 'token-id) "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" (read-msg 'token-id) 1.0 2.0 2.0 {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
+      {"name": "marmalade.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
+      {"name": "marmalade.ledger.TRANSFER","params": [(read-msg 'token-id) "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
+      {"name": "marmalade.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
     (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -99,7 +99,7 @@
   })
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade.ledger.MINT "t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" 1.0)
+   ,'caps: [(marmalade.ledger.MINT "t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" 1.0)
             (marmalade.ledger.MINT "t:mXoVZ-STyWr5aAyVXpgjRAkD5Cpgs33pG7mVQiftTrk" "k:account" 1.0)
    ]
    }])
@@ -157,7 +157,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-    (marmalade.ledger.OFFER "t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+    (marmalade.ledger.OFFER "t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
     }])
 
   (expect "stat offer by running step 0 of sale"
@@ -168,12 +168,12 @@
 
   (expect "events"
     (format "{}" [[
-      {"name": "marmalade.ledger.OFFER","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" 1.0 "2023-07-22T11:26:35Z"]}
-      {"name": "marmalade.ledger.SALE","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-      {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" 1.0 2.0 2.0 {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
-      {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
-      {"name": "marmalade.ledger.TRANSFER","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
-      {"name": "marmalade.ledger.RECONCILE","params": ["t:wWuXGBDTOwrlhwFPnmPPETjyWXPNMa3GTJQSCGDBw7o" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
+      {"name": "marmalade.ledger.OFFER","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" 1.0 "2023-07-22T11:26:35Z"]}
+      {"name": "marmalade.ledger.SALE","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade.fungible-quote-policy-v1.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" "t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" 1.0 2.0 2.0 {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-guard": (read-keyset 'seller-guard )}]}
+      {"name": "marmalade.ledger.ACCOUNT_GUARD","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
+      {"name": "marmalade.ledger.TRANSFER","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
+      {"name": "marmalade.ledger.RECONCILE","params": ["t:_32y1dNvPtMpUdJgSaJIOoUkpwd9AckPMAFENnDZ7AY" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE","current": 1.0,"previous": 0.0}]}]])
     (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 
@@ -262,7 +262,7 @@
   (env-sigs [
     { 'key: 'seller
     ,'caps: [
-    (marmalade.ledger.MINT "t:SpPjVGeY6S4JEMRyokN2qATtslFHN91hEmzNGrw-ViA" "k:account" 1.0)]
+    (marmalade.ledger.MINT (read-msg 'token-id) "k:account" 1.0)]
   }])
 
   (expect "mint 1.0 amount "

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -167,7 +167,7 @@
 
   (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}})
 
-  (expect "events" 
+  (expect "events"
     (format "{}" [[
       {"name": "marmalade.ledger.OFFER","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0 "2023-07-22T11:26:35Z"]}
       {"name": "marmalade.ledger.SALE","params": ["t:x2ei8hWjzQW_ozuq075Kf7YzgdLxQ3dBWZbb_7PegN4" "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -147,8 +147,16 @@
 (env-data {
   "ns": "marmalade"
   })
-  (namespace 'marmalade)
   (namespace (read-msg 'ns))
+  (use marmalade.ledger)
+  (use marmalade.util-v1)
+  (env-data {
+    'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)  } )
+    })
+
+  (expect  "create a token "
+    true
+    (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT)  ))
 
   (module non-fungible-policy-v1 GOVERNANCE
 
@@ -228,14 +236,14 @@
 
   (use marmalade.policy-manager)
   (use marmalade.policy-manager [NON_FUNGIBLE_POLICY])
-  (use marmalade.util-v1)
-  (use marmalade.ledger)
+
   (expect "upgrade non-fungible-policy"
     true
     (update-concrete-policy NON_FUNGIBLE_POLICY marmalade.non-fungible-policy-v1))
+
   (expect "check if stored policy matches with saved concrete-policy"
     true
-    (is-used (at 'policies (get-token-info "t:9BJQ9Qyqfq4pmDGC18xjAao3ZclVz3jFATq2LBBgIpQ")) NON_FUNGIBLE_POLICY))
+    (is-used (at 'policies (get-token-info (read-msg 'token-id))) NON_FUNGIBLE_POLICY))
 
 (rollback-tx)
 


### PR DESCRIPTION
- Removal of Adjustable Policies 
- Removal of `token-policies` schema, and replace with `[module{kip.token-policy-v2}]`
- Removal of distinction of `concrete` and `immutable` policies in the `ledger`. `concrete-policies` are distinguished in policy manager 
- Removal of `enforce-crosschain` in `token-policy-v2`
- Addition of `TOKEN_COLLECTION` event in collection policy at `create-token`
- Bug fix for `get-**-guard` lookup functions