### PR TITLE
Make marmalade v2 compliant with Pact > 4.4 and namespaced keysets

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -6,7 +6,7 @@
   @doc "Collection token policy."
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin)))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (implements kip.token-policy-v2)
 

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -4,7 +4,7 @@
 (module guard-policy-v1 GOVERNANCE
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -5,7 +5,7 @@
   @doc "Concrete policy for issuing an nft with a fixed supply of 1"
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -5,7 +5,7 @@
   @doc "Concrete policy to support royalty payouts in a specified fungible during sale."
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (use marmalade.policy-manager)
   (use marmalade.quote-manager)

--- a/pact/kip/manifest.pact
+++ b/pact/kip/manifest.pact
@@ -3,7 +3,7 @@
 (module token-manifest GOVERNANCE
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (defschema mf-uri
     scheme:string

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -40,7 +40,7 @@
   ;;
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin)))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   ;;
   ;; poly-fungible-v3 caps

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -13,7 +13,7 @@
   )
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (defconst DEFAULT:object{concrete-policy-bool}
     { 'non-fungible-policy: true

--- a/pact/ns-marmalade.pact
+++ b/pact/ns-marmalade.pact
@@ -1,9 +1,10 @@
-(define-keyset 'marmalade-admin)
-(ns.write-registry (read-msg 'ns) (keyset-ref-guard 'marmalade-admin) true)
-(define-namespace
-  (read-msg 'ns)
-  (keyset-ref-guard 'marmalade-admin )
-  (keyset-ref-guard 'marmalade-admin )
-)
-(namespace (read-msg 'ns))
-(enforce-keyset 'marmalade-admin)
+(let ((admin-ks (read-keyset 'marmalade-admin)))
+  (ns.write-registry (read-msg 'ns) admin-ks true)
+  (define-namespace
+    (read-msg 'ns)
+    admin-ks
+    admin-ks)
+
+  (namespace (read-msg 'ns))
+  (define-keyset (+ (read-msg 'ns) ".marmalade-admin")
+                 admin-ks))

--- a/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+++ b/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
@@ -5,7 +5,7 @@
   @doc "Policy for minting with a fixed issuance"
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])

--- a/pact/policies/migration-policy/migration-policy-v1.pact
+++ b/pact/policies/migration-policy/migration-policy-v1.pact
@@ -8,7 +8,7 @@
   (use kip.token-policy-v2 [token-info])
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (defschema migration
     token-id-v1:string

--- a/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
+++ b/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
@@ -9,7 +9,7 @@
   (use kip.token-policy-v2 [token-info])
 
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (defschema manifest-spec
     manifest:object{manifest}

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -3,7 +3,7 @@
 (module policy-manager GOVERNANCE
 
   (defcap GOVERNANCE ()
-    (enforce-guard 'marmalade-admin ))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   (use kip.token-policy-v2 [token-info])
   (use marmalade.quote-manager)

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -157,8 +157,7 @@
 
     @doc "Concrete policy for issuing an nft with a fixed supply of 1"
 
-    (defcap GOVERNANCE ()
-      (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (defcap GOVERNANCE () true)
 
     (implements kip.token-policy-v2)
     (use kip.token-policy-v2 [token-info])

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -6,8 +6,14 @@
   (load "../root/fungible-v2.pact")
   (load "../root/fungible-xchain-v1.pact")
   (load "../root/gas-payer-v1.pact")
+
+  ; Keep DisablePact44 flag for the creation of the Namespace manager module
+  ; (not compliant with namespaced keysets) but remove it as soon it is not
+  ; needed anymore
   (env-exec-config ["DisablePact44"])
   (load "../root/ns.pact")
+  (env-exec-config [])
+
   (define-namespace 'kip (sig-keyset) (sig-keyset))
 
   (load "../kip/account-protocols-v1.pact")

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -7,7 +7,7 @@
   (use util.guards1)
 
   (defcap GOVERNANCE ()
-    (enforce-guard 'marmalade-admin ))
+    (enforce-keyset "marmalade.marmalade-admin"))
 
   ;; Saves Policy Manager Guard information
   (defschema policy-manager

--- a/pact/test/abc.pact
+++ b/pact/test/abc.pact
@@ -10,8 +10,7 @@
 
   (deftable ledger:{entry})
 
-  (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+  (defcap GOVERNANCE () true)
 
   (defcap DEBIT (sender:string)
     (enforce-guard (at 'guard (read ledger sender))))


### PR DESCRIPTION
Marmalade is an official Kadena module. It shouldn't use stuffs that are deprecated since years. Namespaced keysets are mandatory since Pact 4.4

This PR:
   - Prefix all governance keysets by `marmalade.`
   - Remove unneeded governance keysets for test/stub tokens
   - Update REPL scripts to create namespaced keysets, and remove the flag "DisablePact44"