### PR TITLE
Move `optional` checks to policy manager from `add-quote` and `update-quote-price`

### DIFF
--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -126,7 +126,7 @@
  [{'key:'buyer
   ,'caps: [
     (marmalade.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (time  "2023-07-22T11:26:35Z") "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
-    (marmalade.abc.TRANSFER "k:buyer" "c:AsVo7qKgAsW4V4ju2x1-U3sALOSBBPjI8UV4UJ3zhpo" 2.0)
+    (marmalade.abc.TRANSFER "k:buyer" "c:fxI0Y77myZacaggonS_TaF8YxH_cGKFoSLMgZVQAUfc" 2.0)
    ]}])
 
 (env-hash (hash "offer-royalty-0"))

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -314,7 +314,7 @@
   [{'key:'buyer
     ,'caps: [
       (marmalade.ledger.BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } ) "k:account" "k:buyer" 1.0 (time "2023-07-22T11:26:35Z") "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
-      (marmalade.abc.TRANSFER "k:buyer" "c:9hyuSMD9jVoKi_RQwSM7_QNR6iwsXhbRdGO39eMToSE" 2.0)
+      (marmalade.abc.TRANSFER "k:buyer" "c:rgckjytlTnv0dAkBHpvxeZWnrmUtnsegdi_KFwJ75PA" 2.0)
     ]}])
 
   (env-hash (hash "offer-0"))

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -117,17 +117,6 @@
     true
   )
 
-  (defcap QUOTE_ESCROW (sale-id:string)
-    @doc "Capability to be used as escrow's capability guard"
-    true
-  )
-
-  (defun get-escrow-account:object{fungible-account} (sale-id:string)
-    { 'account: (create-principal (create-capability-guard (QUOTE_ESCROW sale-id)))
-    , 'guard: (create-capability-guard (QUOTE_ESCROW sale-id))
-    })
-
-
 ;; Quote storage functions
 
   (defun update-quote-guards:bool (sale-id:string quote-guards:[guard])
@@ -211,65 +200,6 @@
       (fungible::enforce-unit sale-price)
       (enforce (< 0.0 price) "Offer price must be positive")
       true)
-  )
-
-  (defun map-escrowed-buy:bool
-    ( sale-id:string
-      token:object{token-info}
-      seller:string
-      buyer:string
-      buyer-guard:guard
-      amount:decimal
-      policies:[module{kip.token-policy-v2}]
-    )
-    (let* (
-           (escrow-account:object{fungible-account} (get-escrow-account sale-id))
-           (quote:object{quote-schema} (get-quote-info sale-id))
-           (spec:object{quote-spec} (at 'spec quote))
-           (fungible:module{fungible-v2} (at 'fungible spec))
-           (seller-account:object{fungible-account} (at 'seller-account spec))
-           (price:decimal (at 'price spec))
-           (sale-price:decimal (floor (* price amount) (fungible::precision)))
-      )
-       ;; transfer fungible to escrow account
-       (fungible::transfer-create buyer (at 'account escrow-account) (at 'guard escrow-account) sale-price)
-
-       (with-capability (QUOTE_ESCROW sale-id)
-         ;; Run policies::enforce-buy
-         (map-buy token seller buyer buyer-guard amount sale-id policies)
-         ;; Transfer Escrow account to seller
-         (let (
-               (balance:decimal (fungible::get-balance (at 'account escrow-account)))
-             )
-             (install-capability (fungible::TRANSFER (at 'account escrow-account) (at 'account seller-account) balance))
-             (fungible::transfer (at 'account escrow-account) (at 'account seller-account) balance)
-         )
-       )
-       true
-    )
-  )
-
-
-  ;;Utility functions
-  (defun token-buy (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string policy:module{kip.token-policy-v2})
-   (policy::enforce-buy token seller buyer buyer-guard amount sale-id))
-
-  (defun map-buy:[bool] (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string policy-list:[module{kip.token-policy-v2}])
-   (map (token-buy token seller buyer buyer-guard amount sale-id) policy-list))
-
-  (defun exists-quote:bool (sale-id:string)
-    @doc "Looks up quote table for quote"
-    (= (take 6 (typeof (try false (get-quote-info sale-id)))) "object")
-  )
-
-  (defun exists-msg-decimal:bool (msg:string)
-    @doc "Checks env-data field and see if the msg is a decimal"
-    (= (typeof  (try false (read-decimal msg))) "decimal")
-  )
-
-  (defun exists-msg-object:bool (msg:string)
-    @doc "Checks env-data field and see if the msg is a object"
-    (= (take 6 (typeof  (try false  (read-msg msg)))) "object")
   )
 )
 

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -118,7 +118,7 @@
     { 'key: 'bidder
     ,'caps: [
         (marmalade.ledger.BUY (read-msg 'token-id) "k:account" "k:bidder"  1.0 (time  "2023-07-22T11:26:35Z") (read-msg 'sale-id))
-        (marmalade.abc.TRANSFER "k:bidder" "c:FIEkD6IB2pXIa6o4yeYjqLVTniF2Zx2V1QCb-5mBTyQ" 20.0)
+        (marmalade.abc.TRANSFER "k:bidder" "c:M6m2sH9QPTyjaNUsJH4ONNcOMqf7hs-sHeLKBtrZ7mw" 20.0)
       ]
     },
     { 'key: 'market


### PR DESCRIPTION
- Changes `optional-add-quote`, `optional-update-quote-price` inside `quote-manager` to `add-quote`, `update-quote-price`, without checking the existence of the message keys
- Moves the check of message keys in the `policy-manager`'s `enforce-offer` and `enforce-buy`