### PR TITLE
Separate buyer and buyer fungible account

### DIFF
--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -91,7 +91,7 @@
        "fungible": marmalade.abc
        ,"price": 2.0
        ,"amount": 1.0
-       ,"seller-account": {
+       ,"seller-fungible-account": {
            "account": "k:account"
           ,"guard": {"keys": ["account"], "pred": "keys-all"}
          }
@@ -116,6 +116,7 @@
 
 (env-data {
   "buyer": "k:buyer"
+ ,"buyer_fungible_account": "k:buyer"
  ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
  })
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -261,7 +261,7 @@
           "fungible": marmalade.abc
           ,"price": 2.0
           ,"amount": 1.0
-          ,"seller-account": {
+          ,"seller-fungible-account": {
               "account": "k:account"
              ,"guard": {"keys": ["account"], "pred": "keys-all"}
             }
@@ -293,7 +293,7 @@
       {"name": "marmalade.ledger.OFFER","params": [(read-msg 'token-id) "k:account" 1.0 "2023-07-22T11:26:35Z"]}
       {"name": "marmalade.ledger.SALE","params": [(read-msg 'token-id) "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
       {"name": "marmalade.quote-manager.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" (read-msg 'token-id)
-        {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-account": {"account": "k:account","guard": (read-keyset 'seller-guard) }}]}
+        {"amount": 1.0,"fungible": marmalade.abc,"price": 2.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'seller-guard) }}]}
       {"name": "marmalade.quote-manager.QUOTE_GUARDS","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" (read-msg 'token-id) (read-keyset 'seller-guard) []]}
       {"name": "marmalade.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
       {"name": "marmalade.ledger.TRANSFER","params": [(read-msg 'token-id) "k:account" "c:kojW5oDBdlmFg0jVWz_mdj1DxlL8OgeH-1OILa1YzzE" 1.0]}
@@ -302,9 +302,10 @@
   )
 
   (env-data {
-    "buyer": "k:buyer"
-  ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
-  ,"market-guard": {"keys": ["market"], "pred": "keys-all"}
+    "buyer_fungible_account": "k:buyer"
+   ,"buyer": "k:buyer"
+   ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
+   ,"market-guard": {"keys": ["market"], "pred": "keys-all"}
   })
 
   (marmalade.abc.create-account "k:buyer" (read-keyset 'buyer-guard))

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -46,7 +46,7 @@
   (defschema quote-spec
     @doc "Quote spec of the sale"
     fungible:module{fungible-v2}
-    seller-account:object{fungible-account}
+    seller-fungible-account:object{fungible-account}
     price:decimal
     amount:decimal
   )
@@ -162,14 +162,14 @@
         (bind quote-spec {
             "fungible":= fungible
            ,"amount":= amount
-           ,"seller-account":= fungible-account
+           ,"seller-fungible-account":= fungible-account
           }
           (update quotes sale-id {
             "spec": {
                 "fungible": fungible
               , "amount": amount
               , "price": price
-              , "seller-account": fungible-account
+              , "seller-fungible-account": fungible-account
               }
             }))
       )
@@ -183,20 +183,20 @@
   )
 
   ;; Validate functions
-  (defun validate-fungible-account (fungible:module{fungible-v2} seller-account:object{fungible-account})
-    (let ((seller-details (fungible::details (at 'account seller-account))))
+  (defun validate-fungible-account (fungible:module{fungible-v2} account:object{fungible-account})
+    (let ((seller-details (fungible::details (at 'account account))))
       (enforce (=
-        (at 'guard seller-details) (at 'guard seller-account))
-            "Seller guard does not match"))
+        (at 'guard seller-details) (at 'guard account))
+            "Account guard does not match"))
   )
 
   (defun validate-quote:bool (quote-spec:object{quote-spec})
     (let* ( (fungible:module{fungible-v2} (at 'fungible quote-spec) )
-            (seller-account:object{fungible-account} (at 'seller-account quote-spec))
+            (seller-fungible-account:object{fungible-account} (at 'seller-fungible-account quote-spec))
             (amount:decimal (at 'amount quote-spec))
             (price:decimal (at 'price quote-spec))
             (sale-price:decimal (* amount price)) )
-      (validate-fungible-account fungible seller-account)
+      (validate-fungible-account fungible seller-fungible-account)
       (fungible::enforce-unit sale-price)
       (enforce (< 0.0 price) "Offer price must be positive")
       true)

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -28,7 +28,7 @@
     }),
     "quote": {
       "spec": {
-        "seller-account": {
+        "seller-fungible-account": {
             "account": "k:account"
            ,"guard": {"keys": ["account"], "pred": "keys-all"}
           }
@@ -112,6 +112,7 @@
     ,"buyer-guard": {"keys": ["bidder"], "pred": "keys-all"}
     ,"market-guard": {"keys": ["market"], "pred": "keys-all"}
     ,"update_quote_price": 20.0
+    ,"buyer_fungible_account": "k:bidder"
   })
 
   (env-sigs [


### PR DESCRIPTION
Just like sellers, buyer's fungible account and it's marmalade account could differ, i.e.,  an escrow account could pay for the fungible, instead of the account receiving the marmalade after the buy. To separate the two buyer accounts,  

- Read `buyer_fungible_account` key from `(read-msg)` , and uses it at `fungible::transfer` inside `policy-manager.map-escrowed-buy`. 

This is required only for quoted sales, and does not apply to non-quoted sales. 