### PR TITLE
Make v2 namespace agnostic

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -47,9 +47,7 @@
     true)
 
   (defun enforce-ledger:bool ()
-    (enforce-guard (marmalade-v2.ledger.ledger-guard))
-    true
-  )
+    (enforce-guard (ledger.ledger-guard)))
 
   (defun create-collection:bool
     ( collection-name:string

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -5,8 +5,10 @@
 
   @doc "Collection token policy."
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-keyset GOVERNANCE-KS))
 
   (implements kip.token-policy-v2)
 

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -1,5 +1,5 @@
 
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module collection-policy-v1 GOVERNANCE
 

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -1,5 +1,5 @@
 
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module guard-policy-v1 GOVERNANCE
 

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -95,8 +95,7 @@
   )
 
   (defun enforce-ledger:bool ()
-    (enforce-guard (marmalade-v2.ledger.ledger-guard))
-  )
+    (enforce-guard (ledger.ledger-guard)))
 
   (defun enforce-init:bool
     ( token:object{token-info}

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -3,8 +3,10 @@
 
 (module guard-policy-v1 GOVERNANCE
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-keyset GOVERNANCE-KS))
 
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -1,4 +1,4 @@
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module non-fungible-policy-v1 GOVERNANCE
 

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -4,8 +4,10 @@
 
   @doc "Concrete policy for issuing an nft with a fixed supply of 1 and precision of 0"
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-keyset GOVERNANCE-KS))
 
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -13,8 +13,7 @@
   (use kip.token-policy-v2 [token-info])
 
   (defun enforce-ledger:bool ()
-  (enforce-guard (marmalade-v2.ledger.ledger-guard))
-  )
+    (enforce-guard (ledger.ledger-guard)))
 
   (defun enforce-init:bool
     ( token:object{token-info}

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -9,9 +9,9 @@
   (defcap GOVERNANCE ()
     (enforce-keyset GOVERNANCE-KS))
 
-  (use marmalade-v2.policy-manager)
-  (use marmalade-v2.quote-manager)
-  (use marmalade-v2.quote-manager [quote-spec quote-schema])
+  (use policy-manager)
+  (use quote-manager)
+  (use quote-manager [quote-spec quote-schema])
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])
 
@@ -43,8 +43,7 @@
   )
 
   (defun enforce-ledger:bool ()
-     (enforce-guard (marmalade-v2.ledger.ledger-guard))
-  )
+    (enforce-guard (ledger.ledger-guard)))
 
   (defun enforce-init:bool
     ( token:object{token-info}

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -1,4 +1,4 @@
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module royalty-policy-v1 GOVERNANCE
 

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -4,8 +4,10 @@
 
   @doc "Concrete policy to support royalty payouts in a specified fungible during sale."
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-keyset GOVERNANCE-KS))
 
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.quote-manager)

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -1,5 +1,3 @@
-(enforce-pact-version "3.7")
-
 (namespace (read-string 'ns))
 
 (interface poly-fungible-v3

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -69,7 +69,7 @@
     @event
   )
 
-  (defcap TOKEN:bool (id:string precision:integer supply:decimal policies:[module{kip.token-policy-v2}] uri:string)
+  (defcap TOKEN:bool (id:string precision:integer supply:decimal policies:[module{token-policy-v2}] uri:string)
     @doc " Emitted when token ID is created."
     @event
   )
@@ -137,7 +137,7 @@
     ( id:string
       precision:integer
       uri:string
-      policies:[module{kip.token-policy-v2}]
+      policies:[module{token-policy-v2}]
     )
     @doc "Create a new token with ID, PRECISION, URI, and POLICY."
     @model

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -1,6 +1,6 @@
 (enforce-pact-version "3.7")
 
-(namespace 'kip)
+(namespace (read-string 'ns))
 
 (interface poly-fungible-v3
 

--- a/pact/kip/token-policy-v2.pact
+++ b/pact/kip/token-policy-v2.pact
@@ -1,4 +1,4 @@
-(namespace 'kip)
+(namespace (read-string 'ns))
 
 (interface token-policy-v2
 

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -1,4 +1,4 @@
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module ledger GOVERNANCE
 

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -39,8 +39,10 @@
   ;; Capabilities
   ;;
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin)))
+    (enforce-keyset GOVERNANCE-KS))
 
   ;;
   ;; poly-fungible-v3 caps

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -11,7 +11,7 @@
   (implements kip.poly-fungible-v3)
   (use kip.poly-fungible-v3 [account-details sender-balance-change receiver-balance-change])
   (use util.fungible-util)
-  (use marmalade-v2.policy-manager)
+  (use policy-manager)
 
   ;;
   ;; Tables/Schemas
@@ -209,7 +209,7 @@
        (enforce-token-reserved id token-details)
       )
       ;; maps policy list and calls policy::enforce-init
-      (marmalade-v2.policy-manager.enforce-init
+      (policy-manager.enforce-init
         { 'id: id, 'supply: 0.0, 'precision: precision, 'uri: uri,  'policies: policies})
 
       (insert tokens id {
@@ -291,7 +291,7 @@
       receiver:string
       amount:decimal
     )
-    (marmalade-v2.policy-manager.enforce-transfer (get-token-info id) sender (account-guard id sender) receiver amount)
+    (policy-manager.enforce-transfer (get-token-info id) sender (account-guard id sender) receiver amount)
   )
 
   (defun transfer-create:bool
@@ -323,7 +323,7 @@
       amount:decimal
     )
     (with-capability (LEDGER)
-      (marmalade-v2.policy-manager.enforce-mint (get-token-info id) account guard amount)
+      (policy-manager.enforce-mint (get-token-info id) account guard amount)
       (with-capability (MINT id account amount)
         (let
           (
@@ -342,7 +342,7 @@
       amount:decimal
     )
     (with-capability (LEDGER)
-      (marmalade-v2.policy-manager.enforce-burn (get-token-info id) account amount)
+      (policy-manager.enforce-burn (get-token-info id) account amount)
       (with-capability (BURN id account amount)
         (let
           (
@@ -527,12 +527,12 @@
     (step-with-rollback
       ;; Step 0: offer
       (with-capability (LEDGER)
-        (marmalade-v2.policy-manager.enforce-offer (get-token-info id) seller amount (pact-id))
+        (policy-manager.enforce-offer (get-token-info id) seller amount (pact-id))
         (with-capability (SALE id seller amount timeout (pact-id))
           (offer id seller amount)))
       ;;Step 0, rollback: withdraw
       (with-capability (LEDGER)
-        (marmalade-v2.policy-manager.enforce-withdraw (get-token-info id) seller amount (pact-id))
+        (policy-manager.enforce-withdraw (get-token-info id) seller amount (pact-id))
         (with-capability (WITHDRAW id seller amount timeout (pact-id))
           (withdraw id seller amount)))
     )
@@ -541,7 +541,7 @@
       (with-capability (LEDGER)
         (let ( (buyer:string (read-msg "buyer"))
                (buyer-guard:guard (read-msg "buyer-guard")) )
-           (marmalade-v2.policy-manager.enforce-buy (get-token-info id) seller buyer buyer-guard amount (pact-id))
+           (policy-manager.enforce-buy (get-token-info id) seller buyer buyer-guard amount (pact-id))
            (with-capability (BUY id seller buyer amount timeout (pact-id))
              (buy id seller buyer buyer-guard amount (pact-id))
            ))))

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -12,8 +12,10 @@
     guard-policy:bool
   )
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-keyset GOVERNANCE-KS))
 
   (defconst DEFAULT:object{concrete-policy-bool}
     { 'non-fungible-policy: true

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -2,8 +2,8 @@
 
 (module util-v1 GOVERNANCE
   (use kip.token-policy-v2)
-  (use marmalade-v2.policy-manager )
-  (use marmalade-v2.policy-manager [CONCRETE_POLICY_LIST NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+  (use policy-manager)
+  (use policy-manager [CONCRETE_POLICY_LIST NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
 
   (defschema concrete-policy-bool
     non-fungible-policy:bool

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -1,4 +1,4 @@
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module util-v1 GOVERNANCE
   (use kip.token-policy-v2)

--- a/pact/ns-marmalade.pact
+++ b/pact/ns-marmalade.pact
@@ -6,6 +6,6 @@
   (keyset-ref-guard 'marmalade-admin )
 )
 (namespace (read-msg 'ns))
-(define-keyset "marmalade-v2.marmalade-admin")
-(enforce-keyset "marmalade-v2.marmalade-admin")
+(define-keyset  (+ (read-msg 'ns) ".marmalade-admin"))
+(enforce-keyset (+ (read-msg 'ns) ".marmalade-admin"))
 (enforce-keyset 'marmalade-admin)

--- a/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+++ b/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
@@ -24,8 +24,7 @@
   )
 
   (defun enforce-ledger:bool ()
-     (enforce-guard (marmalade-v2.ledger.ledger-guard))
-  )
+    (enforce-guard (ledger.ledger-guard)))
 
   (defun enforce-init:bool
     ( token:object{token-info}

--- a/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+++ b/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
@@ -4,8 +4,10 @@
 
   @doc "Policy for minting with a fixed issuance"
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-keyset GOVERNANCE-KS))
 
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])

--- a/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+++ b/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
@@ -1,4 +1,4 @@
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module fixed-issuance-policy-v1 GOVERNANCE
 

--- a/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
+++ b/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
@@ -1,4 +1,4 @@
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module onchain-manifest-policy-v1 GOVERNANCE
 

--- a/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
+++ b/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
@@ -30,8 +30,7 @@
   )
 
   (defun enforce-ledger:bool ()
-     (enforce-guard (marmalade-v2.ledger.ledger-guard))
-  )
+    (enforce-guard (ledger.ledger-guard)))
 
   (defun get-manifest:object{manifest} (token-id:string)
     (with-read manifests token-id {

--- a/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
+++ b/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
@@ -8,8 +8,10 @@
   (use kip.token-manifest)
   (use kip.token-policy-v2 [token-info])
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+    (enforce-keyset GOVERNANCE-KS))
 
   (defschema manifest-spec
     manifest:object{manifest}

--- a/pact/policy-manager/manager-init.pact
+++ b/pact/policy-manager/manager-init.pact
@@ -1,8 +1,10 @@
-(use marmalade-v2.policy-manager [NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+(namespace (read-string 'ns))
 
-(marmalade-v2.policy-manager.init (marmalade-v2.ledger.ledger-guard))
-(marmalade-v2.quote-manager.init (marmalade-v2.policy-manager.policy-manager-guard))
-(marmalade-v2.policy-manager.write-concrete-policy NON_FUNGIBLE_POLICY marmalade-v2.non-fungible-policy-v1)
-(marmalade-v2.policy-manager.write-concrete-policy ROYALTY_POLICY marmalade-v2.royalty-policy-v1)
-(marmalade-v2.policy-manager.write-concrete-policy COLLECTION_POLICY marmalade-v2.collection-policy-v1)
-(marmalade-v2.policy-manager.write-concrete-policy GUARD_POLICY marmalade-v2.guard-policy-v1)
+(use policy-manager [NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+
+(policy-manager.init (ledger.ledger-guard))
+(quote-manager.init (policy-manager.policy-manager-guard))
+(policy-manager.write-concrete-policy NON_FUNGIBLE_POLICY non-fungible-policy-v1)
+(policy-manager.write-concrete-policy ROYALTY_POLICY royalty-policy-v1)
+(policy-manager.write-concrete-policy COLLECTION_POLICY collection-policy-v1)
+(policy-manager.write-concrete-policy GUARD_POLICY guard-policy-v1)

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -1,4 +1,4 @@
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module policy-manager GOVERNANCE
 

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -2,8 +2,10 @@
 
 (module policy-manager GOVERNANCE
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-keyset GOVERNANCE-KS))
 
   (use kip.token-policy-v2 [token-info])
   (use marmalade-v2.quote-manager)

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -8,8 +8,8 @@
     (enforce-keyset GOVERNANCE-KS))
 
   (use kip.token-policy-v2 [token-info])
-  (use marmalade-v2.quote-manager)
-  (use marmalade-v2.quote-manager [quote-spec quote-msg fungible-account])
+  (use quote-manager)
+  (use quote-manager [quote-spec quote-msg fungible-account])
 
   (defconst QUOTE-MSG-KEY "quote"
     @doc "Payload field for quote spec")

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -15,7 +15,7 @@
   { 'marmalade-admin: ["marmalade-admin"]
   , 'marmalade-ns-user: ["marmalade-admin"]
   , 'marmalade-ns-admin: ["marmalade-admin"]
-  , 'ns: "marmalade-v2"
+  , 'ns: "kip"
   , 'upgrade: false })
 
   (load "../kip/manifest.pact")

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -6,8 +6,10 @@
   (use kip.token-policy-v2 [token-info])
   (use util.guards1)
 
+  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-keyset GOVERNANCE-KS))
 
   ;; Saves Policy Manager Guard information
   (defschema policy-manager

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -1,4 +1,4 @@
-(namespace (read-msg 'ns))
+(namespace (read-string 'ns))
 
 (module quote-manager GOVERNANCE
 

--- a/pact/yaml/testnet/account-protocols-v1.yaml
+++ b/pact/yaml/testnet/account-protocols-v1.yaml
@@ -1,14 +1,10 @@
 codeFile: ../../kip/account-protocols-v1.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
-data:
-  ns: "kip"
-  upgrade: false
-networkId: testnet04
-nonce: "install account-protocols-v1 interface"
+  - public: {{sender_key}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/concrete-policies/collection-policy-v1.yaml
+++ b/pact/yaml/testnet/concrete-policies/collection-policy-v1.yaml
@@ -1,14 +1,13 @@
-codeFile: ../../concrete-policies/collection-policy-v1.pact
+codeFile: ../../concrete-policies/collection-policy/collection-policy-v1.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "marmalade-v2"
-  upgrade: false
-networkId: testnet04
-nonce: "install marmalade-v2.collection-policy-v1"
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/concrete-policies/guard-policy-v1.yaml
+++ b/pact/yaml/testnet/concrete-policies/guard-policy-v1.yaml
@@ -1,14 +1,13 @@
-codeFile: ../../concrete-policies/guard-policy-v1.pact
+codeFile: ../../concrete-policies/guard-policy/guard-policy-v1.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "marmalade-v2"
-  upgrade: false
-networkId: testnet04
-nonce: "install marmalade-v2.guard-token-policy"
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
-  ttl: 15000
+  ttl: 600

--- a/pact/yaml/testnet/concrete-policies/non-fungible-policy-v1.yaml
+++ b/pact/yaml/testnet/concrete-policies/non-fungible-policy-v1.yaml
@@ -1,14 +1,13 @@
-codeFile: ../../concrete-policies/non-fungible-policy-v1.pact
+codeFile: ../../concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "marmalade-v2"
-  upgrade: false
-networkId: testnet04
-nonce: "install marmalade-v2.non-fungible-policy-v1"
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/concrete-policies/royalty-policy-v1.yaml
+++ b/pact/yaml/testnet/concrete-policies/royalty-policy-v1.yaml
@@ -1,14 +1,13 @@
-codeFile: ../../concrete-policies/royalty-policy-v1.pact
+codeFile: ../../concrete-policies/royalty-policy/royalty-policy-v1.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "marmalade-v2"
-  upgrade: false
-networkId: testnet04
-nonce: "install marmalade-v2.royalty-policy-v1"
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/fungible-util.yaml
+++ b/pact/yaml/testnet/fungible-util.yaml
@@ -1,14 +1,10 @@
 codeFile: ../../util/fungible-util.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
-data:
-  ns: "util"
-  upgrade: true
-networkId: testnet04
-nonce: "install util.fungible-util"
+  - public: {{sender_key}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/ledger.yaml
+++ b/pact/yaml/testnet/ledger.yaml
@@ -1,14 +1,13 @@
 codeFile: ../../ledger.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "marmalade-v2"
-  upgrade: false
-networkId: testnet04
-nonce: install-marmalade.ledger
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/manifest.yaml
+++ b/pact/yaml/testnet/manifest.yaml
@@ -1,14 +1,10 @@
 codeFile: ../../kip/manifest.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
-data:
-  ns: "kip"
-  upgrade: false
-networkId: testnet04
-nonce: "install kip.token-manifest"
+  - public: {{sender_key}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/ns-kip.yaml
+++ b/pact/yaml/testnet/ns-kip.yaml
@@ -1,8 +1,8 @@
 codeFile: ../../ns-kip.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "kip"
+  ns: {{kip_namespace}}
   kip-ns-user:
     keys:
       - dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
@@ -15,11 +15,10 @@ data:
       - 8c59a322800b3650f9fc5b6742aa845bc1c35c2625dabfe5a9e9a4cada32c543
       - 5d3dbd0c7e9902de1a868b3410462b034760264c910091f3e0d117397ab394e6
     pred: keys-any
-networkId: testnet04
-nonce: install namespace kip
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 5000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/ns-marmalade.yaml
+++ b/pact/yaml/testnet/ns-marmalade.yaml
@@ -1,8 +1,8 @@
 codeFile: ../../ns-marmalade.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "marmalade-v2"
+  ns: {{marmalade_namespace}}
   marmalade-ns-user:
     keys:
       - dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
@@ -15,11 +15,10 @@ data:
       - 8c59a322800b3650f9fc5b6742aa845bc1c35c2625dabfe5a9e9a4cada32c543
       - 5d3dbd0c7e9902de1a868b3410462b034760264c910091f3e0d117397ab394e6
     pred: keys-any
-networkId: testnet04
-nonce: install namespace marmalade-v2
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: "{{sender}}
   gasLimit: 5000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/policy-init.yaml
+++ b/pact/yaml/testnet/policy-init.yaml
@@ -1,13 +1,12 @@
 codeFile: ../../policy-manager/manager-init.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "marmalade-v2"
-networkId: testnet04
-nonce: init policy manager and quote manager
+  ns: {{marmalade_namespace}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 5000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/policy-manager.yaml
+++ b/pact/yaml/testnet/policy-manager.yaml
@@ -1,0 +1,13 @@
+codeFile: ../../policy-manager/policy-manager.pact
+signers:
+  - public: {{sender_key}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 600

--- a/pact/yaml/testnet/poly-fungible-v3.yaml
+++ b/pact/yaml/testnet/poly-fungible-v3.yaml
@@ -1,13 +1,12 @@
 codeFile: ../../kip/poly-fungible-v3.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "kip"
-networkId: testnet04
-nonce: "install kip.poly-fungible-v3"
+  ns: {{kip_namespace}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/quote-manager.yaml
+++ b/pact/yaml/testnet/quote-manager.yaml
@@ -1,0 +1,13 @@
+codeFile: ../../quote-manager/quote-manager.pact
+signers:
+  - public: {{sender_key}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 600

--- a/pact/yaml/testnet/testnet.yaml
+++ b/pact/yaml/testnet/testnet.yaml
@@ -1,0 +1,7 @@
+network: testnet04
+chain: 1
+marmalade_namespace: marmalade-v2
+kip_namespace: kip
+is_upgrade: false
+sender: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+sender_key: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e

--- a/pact/yaml/testnet/testnet_ps.yaml
+++ b/pact/yaml/testnet/testnet_ps.yaml
@@ -1,0 +1,9 @@
+network: testnet04
+chain: 1
+#marmalade_namespace: marmalade-v2
+#kip_namespace: kip
+marmalade_namespace: n_f65129665a8e0ccbba2e068797085cd85bb82aeb
+kip_namespace: n_f65129665a8e0ccbba2e068797085cd85bb82aeb
+is_upgrade: false
+sender: k:bf98930d4f1fcb8f3c4a5df1776dc26f8464c65d5486259fcc17baa861a866a6
+sender_key: bf98930d4f1fcb8f3c4a5df1776dc26f8464c65d5486259fcc17baa861a866a6

--- a/pact/yaml/testnet/token-policy-v2.yaml
+++ b/pact/yaml/testnet/token-policy-v2.yaml
@@ -1,13 +1,12 @@
 codeFile: ../../kip/token-policy-v2.pact
 signers:
-  - public: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+  - public: {{sender_key}}
 data:
-  ns: "kip"
-networkId: testnet04
-nonce: "install kip.token-policy-v2"
+  ns: {{kip_namespace}}
+networkId: {{network}}
 publicMeta:
-  chainId: "1"
-  sender: "dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e"
+  chainId: "{{chain}}"
+  sender: {{sender}}
   gasLimit: 100000
   gasPrice: 0.0000001
   ttl: 600

--- a/pact/yaml/testnet/util-v1.yaml
+++ b/pact/yaml/testnet/util-v1.yaml
@@ -1,0 +1,13 @@
+codeFile: ../../marmalade-util/util-v1.pact
+signers:
+  - public: {{sender_key}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 600


### PR DESCRIPTION
This PR aims to make Marmalade v2 deployable on any namespace.
Now, the `ns` parameter is fully recognized. (related to https://github.com/kadena-io/marmalade/issues/104).

The admin keyset is now relative to the current namespace.
Reference between modules are also relative.

This PR changes the YAML files as well to make many things as variable parameters. I added also some missing YAML files.
This was needed to deploy my own testing Marmalade instance. 

The only remaining issue is when interfaces are a deployed in a different NS than `kip`: some files need to be manually edited to fix the links. 

I fixed some other small issues:
   - old `(enforce-pact-version)` in a file
   - remove static nonces in YAML file (A nonce is a nonce)
   - change `(read-msg)` to `(read-string)` for`ns`, since only strings are expected in this case.