### PR TITLE
Fix typechecker

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -78,7 +78,9 @@
         "max-size":= max-size
        ,"size":= size
         }
-      (if (= 0 max-size) "No size limit" (enforce (> max-size size) "Exceeds collection size"))
+
+      ; max-size=0 means unlimited collection
+      (enforce (or? (= 0) (< size) max-size) "Exceeds collection size")
 
       (update collections collection-id {
         "size": (+ 1 size)

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -121,10 +121,10 @@
         (enforce (= (at 'token-id quote) (at 'id token)) "incorrect sale token")
         (if
           (> royalty-payout 0.0)
-          [ (install-capability (fungible::TRANSFER escrow-account creator royalty-payout))
+          (let ((_ ""))
+            (install-capability (fungible::TRANSFER escrow-account creator royalty-payout))
             (emit-event (ROYALTY sale-id (at 'id token) royalty-payout creator))
-            (fungible::transfer escrow-account creator royalty-payout)
-          ]
+            (fungible::transfer escrow-account creator royalty-payout))
           "No royalty"
           )))
         true)

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -400,20 +400,14 @@
                (= old-bal -1.0))
              (old-bal:decimal (if is-new 0.0 old-bal))
              (new-bal:decimal  (+ old-bal amount)))
-      (if is-new
-        [ (insert ledger (key id account)
-            { "balance" : new-bal
-            , "guard"   : guard
-            , "id" : id
-            , "account" : account
-            })
-          (emit-event (ACCOUNT_GUARD id account guard))]
-        [ (update ledger (key id account)
-           { "balance" : new-bal }
-          )
-         ]
-        )
-      {'account: account, 'previous: old-bal, 'current: new-bal}
+        (write ledger (key id account)
+           { "balance" : new-bal
+           , "guard"   : guard
+           , "id" : id
+           , "account" : account
+           })
+        (if is-new (emit-event (ACCOUNT_GUARD id account guard)) true)
+        {'account: account, 'previous: old-bal, 'current: new-bal}
       ))
     )
 

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -274,12 +274,14 @@
 
   (defun exists-msg-decimal:bool (msg:string)
     @doc "Checks env-data field and see if the msg is a decimal"
-    (try false (let ((d (read-decimal msg))) true))
+    (let  ((d:decimal (try -1.0 (read-decimal msg))))
+      (!= d -1.0))
   )
 
   (defun exists-msg-quote:bool (msg:string)
     @doc "Checks env-data field and see if the msg is a object"
-    (try false (let ((o (read-msg msg))) true))
+    (let ((o:object (try {} (read-msg msg))))
+      (!= o {}))
   )
 
  (defun token-init (token:object{token-info} policy:module{kip.token-policy-v2})

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -120,14 +120,13 @@
   (defun update-quote-guards:bool (sale-id:string quote-guards:[guard])
     @doc "Updates quote-guards if signed by the seller guard"
     (with-capability (UPDATE_QUOTE_GUARD sale-id)
-      (with-read quotes {
+      (with-read quotes sale-id {
           "token-id":=token-id
          ,"seller-guard":= seller-guard
         }
-        (update quotes {
+        (update quotes sale-id {
           "quote-guards": quote-guards
         })
-        true
     (emit-event (QUOTE_GUARDS sale-id token-id seller-guard quote-guards))))
   )
 


### PR DESCRIPTION
This PR fix some various issues thrown by the typechecker:
  - Non uniform lists (royalty-policy)
  - Non uniform THEN/ELSE returns in a `(if` (collection-policy and ledger)
  - Missing types (policy-manager)
  - Uncaught errors in dead code (quote-manager)

The issue in ledger has been resolved by simplifying the `(credit)` code: replace a complex `(if ....  (update) (insert) )` => to a simple `(write)`