### PR TITLE
Uniform msg-data read methods across policies

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -28,6 +28,8 @@
   (deftable collections:{collection})
   (deftable tokens:{token})
 
+  (defconst COLLECTION-ID-MSG-KEY:string "collection_id")
+
   (defcap OPERATOR (collection-id:string)
     @doc "Capability to grant creation of a collection's token"
     (with-read collections collection-id {
@@ -69,9 +71,11 @@
   )
 
   (defun enforce-init:bool (token:object{token-info})
+    @doc "collection-id"
+
     (enforce-ledger)
     (let* ( (token-id:string  (at 'id token))
-            (collection-id:string (read-msg "collection-id")) )
+            (collection-id:string (read-msg COLLECTION-ID-MSG-KEY)) )
     ;;Enforce operator guard
     (with-capability (OPERATOR collection-id)
       (with-read collections collection-id {

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -56,6 +56,11 @@
       collection-size:integer
       operator-guard:guard
       )
+      @doc "Executed directly from the policy, required to succeed before `create-token` \
+      \ step for collection tokens.                                                      \
+      \ Required msg-data keys:                                                          \
+      \ * collection_id:string - registers the token to a collection and emits           \
+      \ TOKEN_COLLECTION event for discovery"
       (enforce (>= collection-size 0) "Collection size must be positive")
       (let ((collection-id:string (create-collection-id collection-name) ))
         (insert collections collection-id {
@@ -71,8 +76,10 @@
   )
 
   (defun enforce-init:bool (token:object{token-info})
-    @doc "collection-id"
-
+    @doc "Executed at `create-token` step of marmalade.ledger.                 \
+    \ Required msg-data keys:                                                  \
+    \ * collection_id:string - registers the token to a collection and emits   \
+    \ TOKEN_COLLECTION event for discovery"
     (enforce-ledger)
     (let* ( (token-id:string  (at 'id token))
             (collection-id:string (read-msg COLLECTION-ID-MSG-KEY)) )

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -27,7 +27,7 @@
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05
     }
-  ,"collection-id": "collection:hSQGbcedpUX030HHNizv3KQokGwdGijDoG7ifTvWKe4"
+  ,"collection_id": "collection:hSQGbcedpUX030HHNizv3KQokGwdGijDoG7ifTvWKe4"
   ,"ks": {"keys": ["operator"], "pred": "keys-all"}
   })
 
@@ -87,12 +87,12 @@
       ,"max-size": 10
       ,"operator-guard": (read-keyset 'ks )
     }
-    (marmalade-v2.collection-policy-v1.get-collection (read-msg 'collection-id)))
+    (marmalade-v2.collection-policy-v1.get-collection (read-msg 'collection_id)))
 
   (expect "token should be part of collection"
     {
       "id": (read-msg 'token-id)
-      ,"collection-id": "collection:hSQGbcedpUX030HHNizv3KQokGwdGijDoG7ifTvWKe4"
+     ,"collection-id": "collection:hSQGbcedpUX030HHNizv3KQokGwdGijDoG7ifTvWKe4"
     }
     (marmalade-v2.collection-policy-v1.get-token (read-msg 'token-id))
   )
@@ -114,7 +114,7 @@
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05
     }
-  ,"collection-id": "collection:k5h38RgwCGX84Sa6VDs0bP4jOs832n1KvQ-95VPg6k8"
+  ,"collection_id": "collection:k5h38RgwCGX84Sa6VDs0bP4jOs832n1KvQ-95VPg6k8"
   ,"ks": {"keys": ["operator"], "pred": "keys-all"}
   })
 
@@ -152,7 +152,7 @@
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05
     }
-  ,"collection-id": "collection:k5h38RgwCGX84Sa6VDs0bP4jOs832n1KvQ-95VPg6k8"
+  ,"collection_id": "collection:k5h38RgwCGX84Sa6VDs0bP4jOs832n1KvQ-95VPg6k8"
   ,"ks": {"keys": ["operator"], "pred": "keys-all"}
   })
 

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -18,10 +18,10 @@
 
   (deftable policy-guards:{guards})
 
-  (defconst MINT_GUARD:string "mint-guard")
-  (defconst BURN_GUARD:string "burn-guard")
-  (defconst SALE_GUARD:string "sale-guard")
-  (defconst TRANSFER_GUARD:string "transfer-guard")
+  (defconst MINT-GUARD-MSG-KEY:string "mint-guard")
+  (defconst BURN-GUARD-MSG-KEY:string "burn-guard")
+  (defconst SALE-GUARD-MSG-KEY:string "sale-guard")
+  (defconst TRANSFER-GUARD-MSG-KEY:string "transfer-guard")
 
   (defconst GUARD_SUCCESS:guard (create-user-guard (success)))
   (defconst GUARD_FAILURE:guard (create-user-guard (failure)))
@@ -101,10 +101,10 @@
     )
     (enforce-ledger)
     (let ((guards:object{guards}
-      { 'mint-guard: (try GUARD_SUCCESS (read-msg MINT_GUARD) ) ;; type error becomes successful guard
-      , 'burn-guard: (try GUARD_SUCCESS (read-msg BURN_GUARD) )
-      , 'sale-guard: (try GUARD_SUCCESS (read-msg SALE_GUARD) )
-      , 'transfer-guard: (try GUARD_SUCCESS (read-msg TRANSFER_GUARD) ) } ))
+      { 'mint-guard: (try GUARD_SUCCESS (read-msg MINT-GUARD-MSG-KEY) ) ;; type error becomes successful guard
+      , 'burn-guard: (try GUARD_SUCCESS (read-msg BURN-GUARD-MSG-KEY) )
+      , 'sale-guard: (try GUARD_SUCCESS (read-msg SALE-GUARD-MSG-KEY) )
+      , 'transfer-guard: (try GUARD_SUCCESS (read-msg TRANSFER-GUARD-MSG-KEY) ) } ))
     (insert policy-guards (at 'id token)
       guards)
     (emit-event (GUARDS guards)) )

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -18,10 +18,10 @@
 
   (deftable policy-guards:{guards})
 
-  (defconst MINT-GUARD-MSG-KEY:string "mint-guard")
-  (defconst BURN-GUARD-MSG-KEY:string "burn-guard")
-  (defconst SALE-GUARD-MSG-KEY:string "sale-guard")
-  (defconst TRANSFER-GUARD-MSG-KEY:string "transfer-guard")
+  (defconst MINT-GUARD-MSG-KEY:string "mint_guard")
+  (defconst BURN-GUARD-MSG-KEY:string "burn_guard")
+  (defconst SALE-GUARD-MSG-KEY:string "sale_guard")
+  (defconst TRANSFER-GUARD-MSG-KEY:string "transfer_guard")
 
   (defconst GUARD_SUCCESS:guard (create-user-guard (success)))
   (defconst GUARD_FAILURE:guard (create-user-guard (failure)))
@@ -58,9 +58,9 @@
 
   (defun get-mint-guard:guard (token-id:string)
     (with-read policy-guards token-id {
-      'mint-guard:= mint-g
+      'mint-guard:= mint-guard
     }
-    mint-g
+    mint-guard
     )
   )
 
@@ -99,6 +99,14 @@
   (defun enforce-init:bool
     ( token:object{token-info}
     )
+    @doc "Executed at `create-token` step of marmalade.ledger. Registers  guards for \
+    \ 'mint', 'burn', 'sale', 'transfer' operations of the created token.            \
+    \ Required msg-data keys:                                                        \
+    \ * (optional) mint_guard:string -  mint-guard and adds success guard if absent. \
+    \ * (optional) burn_guard:string -  burn-guard and adds success guard if absent. \
+    \ * (optional) sale_guard:string -  sale-guard and adds success guard if absent. \
+    \ * (optional) transfer_guard:string -  transfer-guard and adds success guard if absent. \
+    \ the created token"
     (enforce-ledger)
     (let ((guards:object{guards}
       { 'mint-guard: (try GUARD_SUCCESS (read-msg MINT-GUARD-MSG-KEY) ) ;; type error becomes successful guard

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -37,7 +37,7 @@
 (env-data {
    "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
   ,"account": "k:account"
-  ,"mint-guard": {"keys": ["mint"], "pred": "keys-all"}
+  ,"mint_guard": {"keys": ["mint"], "pred": "keys-all"}
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
 })
 

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -24,7 +24,7 @@
   (deftable royalties:{royalty-schema})
 
   (defconst ROYALTY-SPEC-MSG-KEY "royalty_spec"
-    @doc "Payload field for token spec")
+    @doc "Payload field for royalty spec")
 
   (defun get-royalty:object{royalty-schema} (token:object{token-info})
     (read royalties (at 'id token))
@@ -47,6 +47,10 @@
   (defun enforce-init:bool
     ( token:object{token-info}
     )
+    @doc "Executed at `create-token` step of marmalade.ledger.      \
+    \ Required msg-data keys:                                                  \
+    \ * royalty_spec:object{royalty-schema} - registers royalty information of \
+    \ the created token"
     (enforce-ledger)
     (let* ( (spec:object{royalty-schema} (read-msg ROYALTY-SPEC-MSG-KEY))
             (fungible:module{fungible-v2} (at 'fungible spec))

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -23,7 +23,7 @@
 
   (deftable royalties:{royalty-schema})
 
-  (defconst ROYALTY_SPEC "royalty_spec"
+  (defconst ROYALTY-SPEC-MSG-KEY "royalty_spec"
     @doc "Payload field for token spec")
 
   (defun get-royalty:object{royalty-schema} (token:object{token-info})
@@ -48,7 +48,7 @@
     ( token:object{token-info}
     )
     (enforce-ledger)
-    (let* ( (spec:object{royalty-schema} (read-msg ROYALTY_SPEC))
+    (let* ( (spec:object{royalty-schema} (read-msg ROYALTY-SPEC-MSG-KEY))
             (fungible:module{fungible-v2} (at 'fungible spec))
             (creator:string (at 'creator spec))
             (creator-guard:guard (at 'creator-guard spec))

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -110,7 +110,7 @@
    }])
 
 (expect "stat offer by running step 0 of sale"
-  true
+  "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"
   (sale (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z")))
 
 (env-data { "recipient-guard": {"keys": ["seller"], "pred": "keys-all"}})
@@ -134,7 +134,7 @@
 (env-hash (hash "offer-royalty-0"))
 
 (expect "Buy succeeds"
-  true
+  "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"
   (continue-pact 1))
 
 (env-data {

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -256,7 +256,7 @@
     @event
   )
 
-  (defpact sale:bool
+  (defpact sale:string
     ( id:string
       seller:string
       amount:decimal

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -510,7 +510,7 @@
 
   (defcap SALE_PRIVATE:bool (sale-id:string) true)
 
-  (defpact sale:bool
+  (defpact sale:string
     ( id:string
       seller:string
       amount:decimal
@@ -521,12 +521,14 @@
       (with-capability (LEDGER)
         (marmalade-v2.policy-manager.enforce-offer (get-token-info id) seller amount (pact-id))
         (with-capability (SALE id seller amount timeout (pact-id))
-          (offer id seller amount)))
+          (offer id seller amount))
+          (pact-id))
       ;;Step 0, rollback: withdraw
       (with-capability (LEDGER)
         (marmalade-v2.policy-manager.enforce-withdraw (get-token-info id) seller amount (pact-id))
         (with-capability (WITHDRAW id seller amount timeout (pact-id))
-          (withdraw id seller amount)))
+          (withdraw id seller amount))
+          (pact-id))
     )
     (step
       ;; Step 1: buy
@@ -536,7 +538,8 @@
            (marmalade-v2.policy-manager.enforce-buy (get-token-info id) seller buyer buyer-guard amount (pact-id))
            (with-capability (BUY id seller buyer amount timeout (pact-id))
              (buy id seller buyer buyer-guard amount (pact-id))
-           ))))
+           ))
+           (pact-id)))
   )
 
   (defun offer:bool

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -1,1 +1,2 @@
 (load "./policy-manager/policy-manager.repl")
+(typecheck "marmalade-v2.ledger")

--- a/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+++ b/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
@@ -31,7 +31,10 @@
   (defun enforce-init:bool
     ( token:object{token-info}
     )
-    @doc ""
+    @doc "The function is run at `create-token` step of marmalade.ledger.      \
+    \ Required msg-data keys:                                                  \
+    \ * fixed_issuance_spec:object{supply-schema} - registers minimum mint     \
+    \ amount, max-supply, and precision information of the created token"
     (enforce-ledger)
     (let* (
             (fixed-issuance-spec:object{supply-schema} (read-msg FIXED-ISSUANCE-SPEC))

--- a/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
+++ b/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
@@ -11,6 +11,8 @@
   (defcap GOVERNANCE ()
     (enforce-guard (keyset-ref-guard 'marmalade-admin )))
 
+  (defconst MANIFEST-SPEC-MSG-KEY:string "manifest_spec")
+
   (defschema manifest-spec
     manifest:object{manifest}
     guard:guard
@@ -54,7 +56,7 @@
     ( token:object{token-info}
     )
     (enforce-ledger)
-    (let ( (manifest:object{manifest-spec} (read-msg 'manifest-spec )) )
+    (let ( (manifest:object{manifest-spec} (read-msg MANIFEST-SPEC-MSG-KEY )) )
       (enforce-verify-manifest (at 'manifest manifest))
       (insert manifests (at 'id token) manifest)
     )

--- a/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
+++ b/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
@@ -55,6 +55,10 @@
   (defun enforce-init:bool
     ( token:object{token-info}
     )
+    @doc "Exected at `create-token` step of marmalade.ledger.                  \
+    \ Required msg-data keys:                                                  \
+    \ * manifest_spec:object{manifest-spec} - registers the manifest object of \
+    \ the token and the guard that manages the upgrade of the manifest on chain"
     (enforce-ledger)
     (let ( (manifest:object{manifest-spec} (read-msg MANIFEST-SPEC-MSG-KEY )) )
       (enforce-verify-manifest (at 'manifest manifest))

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -163,6 +163,10 @@
       seller:string
       amount:decimal
       sale-id:string )
+    @doc " Executed at `offer` step of marmalade.ledger.                             \
+    \ Required msg-data keys:                                                        \
+    \ * (optional) quote:object{quote-msg} - sale is registered as a quoted fungible \
+    \ sale if present. If absent, sale proceeds without quotes."
     (enforce-ledger)
     (enforce-sale-pact sale-id)
     (with-capability (POLICY_MANAGER)
@@ -179,6 +183,7 @@
       seller:string
       amount:decimal
       sale-id:string )
+    @doc " Executed at `withdraw` step of marmalade.ledger."
     (enforce-ledger)
     (enforce-sale-pact sale-id)
     (with-capability (POLICY_MANAGER)
@@ -191,6 +196,11 @@
       buyer-guard:guard
       amount:decimal
       sale-id:string )
+      @doc " Executed at `buy` step of marmalade.ledger.                                 \
+      \ Required msg-data keys:                                                          \
+      \ * (optional) buyer_fungible_account:string - The fungible account of the buyer   \
+      \ which transfers the fungible to the escrow account. Only required if the sale is \
+      \ a quoted sale. "
     (enforce-ledger)
     (enforce-sale-pact sale-id)
     (with-capability (POLICY_MANAGER)

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -9,13 +9,13 @@
   (use marmalade-v2.quote-manager)
   (use marmalade-v2.quote-manager [quote-spec quote-msg fungible-account])
 
-  (defconst QUOTE-MSG-KEY "quote"
+  (defconst QUOTE-MSG-KEY:string "quote"
     @doc "Payload field for quote spec")
 
-  (defconst UPDATE-QUOTE-PRICE-MSG-KEY "update_quote_price"
+  (defconst UPDATE-QUOTE-PRICE-MSG-KEY:string "update_quote_price"
     @doc "Payload field for quote spec")
 
-  (defconst BUYER-FUNGIBLE-ACCOUNT-MSG-KEY "buyer_fungible_account"
+  (defconst BUYER-FUNGIBLE-ACCOUNT-MSG-KEY:string "buyer_fungible_account"
     @doc "Payload field for buyer's fungible account")
 
   (defcap POLICY_MANAGER:bool ()

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -54,7 +54,7 @@
 (commit-tx)
 
 (typecheck "marmalade-v2.policy-manager")
-(typecheck "marmalade-v2.ledger")
+
 (begin-tx "load concrete-polices")
   (load "../concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact")
   (load "../concrete-policies/royalty-policy/royalty-policy-v1.pact")
@@ -276,7 +276,7 @@
     }])
 
   (expect "start offer by running step 0 of sale"
-    true
+    "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"
     (sale (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z")))
 
   (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -316,7 +316,7 @@
 
   (env-hash (hash "offer-0"))
   (expect "Buy succeeds"
-    true
+    "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"
     (continue-pact 1))
 
   (env-data {


### PR DESCRIPTION
- Uniformed the `msg-data-key`'s required in the policies, and the managers, to underscores for spaces, and add defconst of the keys. 
- Added docs for functions that require `msg-data` fields 
- Returns `(pact-id)` at defpact `ledger.sale`
- Adds precision check to `fixed-issuance-policy-v1`, and add `fixed_issuance_spec` instead. 