### PR TITLE
Making timeout optional for sale

### DIFF
--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -32,6 +32,18 @@
 (commit-tx)
 
 (begin-tx)
+  (module util GOVERNANCE
+    (defcap GOVERNANCE ()
+      false)
+
+    (defun to-timestamp:decimal (input:time)
+      "Computes an Unix timestamp of the input date"
+      (diff-time input (time "1970-01-01T00:00:00Z"))
+    )
+  )
+(commit-tx)
+
+(begin-tx)
 (use marmalade-v2.ledger)
 
 (use marmalade-v2.util-v1)
@@ -106,12 +118,12 @@
 (env-sigs [
   { 'key: 'account
    ,'caps: [
-   (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+   (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) )]
    }])
 
 (expect "stat offer by running step 0 of sale"
   true
-  (sale (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z")))
+  (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
 
 (env-data { "recipient-guard": {"keys": ["seller"], "pred": "keys-all"}})
 
@@ -127,7 +139,7 @@
 (env-sigs
  [{'key:'buyer
   ,'caps: [
-    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (time  "2023-07-22T11:26:35Z") "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (util.to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
     (marmalade-v2.abc.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
    ]}])
 

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -251,7 +251,7 @@
   ;;
 
   (defcap SALE:bool
-    (id:string seller:string amount:decimal timeout:time sale-id:string)
+    (id:string seller:string amount:decimal timeout:decimal sale-id:string)
     @doc "Wrapper cap/event of SALE of token ID by SELLER of AMOUNT until TIMEOUT block height."
     @event
   )
@@ -260,7 +260,7 @@
     ( id:string
       seller:string
       amount:decimal
-      timeout:time
+      timeout:decimal
     )
     @doc " Offer->buy escrow pact of AMOUNT of token ID by SELLER with TIMEOUT in blocks. \
          \ Step 1 is offer with withdraw rollback after timeout. \

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -493,7 +493,7 @@
     @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after timeout."
     @managed
     (enforce-one [
-      (enforce (= 0 timeout) "No timeout set")
+      (enforce (= 0.0 timeout) "No timeout set")
       (enforce (not (sale-active timeout)) "WITHDRAW: still active")
     ])
     (compose-capability (DEBIT id (sale-account)))

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -470,7 +470,7 @@
   ;;
 
   (defcap SALE:bool
-    (id:string seller:string amount:decimal timeout:time sale-id:string)
+    (id:string seller:string amount:decimal timeout:decimal sale-id:string)
     @doc "Wrapper cap/event of SALE of token ID by SELLER of AMOUNT until TIMEOUT block height."
     @event
     (enforce (> amount 0.0) "Amount must be positive")
@@ -480,7 +480,7 @@
   )
 
   (defcap OFFER:bool
-    (id:string seller:string amount:decimal timeout:time)
+    (id:string seller:string amount:decimal timeout:decimal)
     @doc "Managed cap for SELLER offering AMOUNT of token ID until TIMEOUT."
     @managed
     (enforce (sale-active timeout) "SALE: invalid timeout")
@@ -489,17 +489,20 @@
   )
 
   (defcap WITHDRAW:bool
-    (id:string seller:string amount:decimal timeout:time sale-id:string)
+    (id:string seller:string amount:decimal timeout:decimal sale-id:string)
     @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after timeout."
     @managed
-    (enforce (not (sale-active timeout)) "WITHDRAW: still active")
+    (enforce-one [
+      (enforce (= 0 timeout) "No timeout set")
+      (enforce (not (sale-active timeout)) "WITHDRAW: still active")
+    ])
     (compose-capability (DEBIT id (sale-account)))
     (compose-capability (CREDIT id seller))
     (compose-capability (SALE_PRIVATE sale-id))
   )
 
   (defcap BUY:bool
-    (id:string seller:string buyer:string amount:decimal timeout:time sale-id:string)
+    (id:string seller:string buyer:string amount:decimal timeout:decimal sale-id:string)
     @doc "Completes sale OFFER to BUYER."
     @managed
     (enforce (sale-active timeout) "BUY: expired")
@@ -514,7 +517,7 @@
     ( id:string
       seller:string
       amount:decimal
-      timeout:time
+      timeout:decimal
     )
     (step-with-rollback
       ;; Step 0: offer
@@ -607,9 +610,12 @@
       true
   ))
 
-  (defun sale-active:bool (timeout:time)
+  (defun sale-active:bool (timeout:decimal)
     @doc "Sale is active until TIMEOUT time."
-    (< (at 'block-time (chain-data)) timeout)
+    (if (= 0.0 timeout)
+      true
+      (< (at 'block-time (chain-data)) (add-time (time "1970-01-01T00:00:00Z") timeout))
+    )
   )
 
   (defun sale-account:string ()

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -28,6 +28,18 @@
 (commit-tx)
 
 (begin-tx)
+(module util GOVERNANCE
+  (defcap GOVERNANCE ()
+    false)
+
+  (defun to-timestamp:decimal (in:time)
+    "Computes an Unix timestamp of the input date"
+    (diff-time in (time "1970-01-01T00:00:00Z"))
+  )
+)
+(commit-tx)
+
+(begin-tx)
   (env-data
    { 'marmalade-admin: ["marmalade-admin"]
    , "marmalade-v2.marmalade-admin": ["marmalade-admin"]
@@ -272,12 +284,12 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-    (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z") )]
+    (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]
     }])
 
   (expect "start offer by running step 0 of sale"
     true
-    (sale (read-msg 'token-id) "k:account" 1.0 (time "2023-07-22T11:26:35Z")))
+    (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
 
   (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}
             , "token-id" : (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
@@ -289,8 +301,8 @@
       {"name": "marmalade-v2.quote-manager.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" (read-msg 'token-id)
         {"amount": 1.0,"fungible": marmalade-v2.abc,"price": 2.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'seller-guard) }}]}
       {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" (read-msg 'token-id) (read-keyset 'seller-guard) []]}
-      {"name": "marmalade-v2.ledger.OFFER","params": [(read-msg 'token-id) "k:account" 1.0 "2023-07-22T11:26:35Z"]}
-      {"name": "marmalade-v2.ledger.SALE","params": [(read-msg 'token-id) "k:account" 1.0 "2023-07-22T11:26:35Z" "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.OFFER","params": [(read-msg 'token-id) "k:account" 1.0 1690025195.0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-msg 'token-id) "k:account" 1.0 1690025195.0 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-msg 'token-id) "k:account" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 1.0,"previous": 0.0}]}]])
@@ -310,7 +322,7 @@
   (env-sigs
   [{'key:'buyer
     ,'caps: [
-      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } ) "k:account" "k:buyer" 1.0 (time "2023-07-22T11:26:35Z") "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } ) "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
       (marmalade-v2.abc.TRANSFER "k:buyer" "c:DzKUkpHP-1-4XUGw1R7WLfXoWtoyICfk6hV437b_IEY" 2.0)
     ]}])
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -28,15 +28,15 @@
 (commit-tx)
 
 (begin-tx)
-(module util GOVERNANCE
-  (defcap GOVERNANCE ()
-    false)
+  (module util GOVERNANCE
+    (defcap GOVERNANCE ()
+      false)
 
-  (defun to-timestamp:decimal (in:time)
-    "Computes an Unix timestamp of the input date"
-    (diff-time in (time "1970-01-01T00:00:00Z"))
+    (defun to-timestamp:decimal (input:time)
+      "Computes an Unix timestamp of the input date"
+      (diff-time input (time "1970-01-01T00:00:00Z"))
+    )
   )
-)
 (commit-tx)
 
 (begin-tx)


### PR DESCRIPTION
The timeout for a sale is a Unix timestamp. When providing `0.0` (it's a decimal) as a timestamp it represents an open ended sale which can be withdrawn at any time.