### PR TITLE
Fix enforce-one bug in the ledger WITHDRAW cap.

### DIFF
--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -492,7 +492,7 @@
     (id:string seller:string amount:decimal timeout:decimal sale-id:string)
     @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after timeout."
     @managed
-    (enforce-one [
+    (enforce-one "WITHDRAW: still active" [
       (enforce (= 0.0 timeout) "No timeout set")
       (enforce (not (sale-active timeout)) "WITHDRAW: still active")
     ])


### PR DESCRIPTION
Fix a bug introduced by https://github.com/kadena-io/marmalade/pull/119.

First argument of `(enforce-one)` is a message string.

Reference: https://pact-language.readthedocs.io/en/stable/pact-functions.html#enforce-one

Looks like the code hasn't been tested, and errors given by Pact ignored.


