### PR TITLE
Fix a bug in add-quote-guard

### DIFF
--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -143,7 +143,7 @@
          ,"quote-guards":= quote-guards
         }
 
-        (let ((updated-guards (+ quote-guards guard)))
+        (let ((updated-guards (+ quote-guards [guard])))
           (update quotes sale-id {
             "quote-guards": updated-guards
           })


### PR DESCRIPTION
Fix a bug in add-quote-guard.

`(+)` operator can only add arguments of the same type: Not a table with an element.
 
Once again, looks like the code hasn't been tested, and errors given by Pact ignored.

Moreover I do not exactly understand the role of this function.

Since the function `(offer-for-auction)` => `(add-quote-guard)` never get called in your example
https://github.com/kadena-io/marmalade/blob/9dd7ec4626eb7fae24b8aaf672457c59403a2a3c/examples/basic-bidding-sale/basic-bidding-sale.pact#L95 

Is it dead code ? Definitely hard to try to build around Marmelade V2.