### PR TITLE
Fix bug in fixed-issuance-policy

### DIFF
--- a/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+++ b/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
@@ -42,9 +42,7 @@
       (enforce (>= (at 'min-amount fixed-issuance-spec) 0.0) "Invalid min-amount")
       (enforce (>= (at 'max-supply fixed-issuance-spec) 0.0) "Invalid max-supply")
       (enforce (= (at 'precision fixed-issuance-spec) (at 'precision token)) "Invalid Precision")
-      (insert supplies (at 'id token)
-        { 'max-supply: (at 'max-supply fixed-issuance-spec)
-        , 'min-amount: (at 'min-amount fixed-issuance-spec) }))
+      (insert supplies (at 'id token) fixed-issuance-spec))
     true
   )
 


### PR DESCRIPTION
Fix a bug in fixed-issuance-policy

https://github.com/kadena-io/marmalade/pull/118 added a new field `precision` in `supply-schema`. But the insert code was not changed to reflect that. In consequence, the module was not working, Pact refused to insert in the table an unsuitable object.

Since the data read from the data section from the transaction is the same type, I simplified the code by inserting directly the read object.