### PR TITLE
Make poly-fungible-v3 more consistent + Change the tokenId and token creation process to prevent frontrunning

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,26 @@ A Token is created in marmalade via running `create-token`. Arguments include:
 - `precision`: Number of decimals allowed for for the token amount. For one-off token, precision must be 0, and should be enforced in the policy's `enforce-init`.
 - `uri`: url to external JSON containing metadata
 - `policies`: policies contract with custom functions to execute at marmalade functions
+- `creation-guard`: Non stored guard (usally a Keyset). Must be used to reserve a `token-id`
 
 `policy-manager.enforce-init` calls `policy:enforce-init` in stored token-policies, and the function is executed in `ledger.create-token`.
+
+#### Creation guard usage
+
+Before creating a token, the creator must choose a temporary guard, which can be
+
+- An usual keyset. (eg: one already used in the guard-policy).
+- But also a single-use keyset, since it isn't stored and won't be needed anymore.
+- Some more complex setups could involve other guard types (eg: when token creations are managed by a SC).
+
+This guard will be part of the `token-id` (starting `t:`) creation. As a consequence, it protects the legit creator from being front-runned during token creation. With this mechanism, only the legit creator who owns the creation key can create a specific `token-id`.
+
+Creation steps:
+
+- Generate a unique `token-id` by calling `(ledger.create-token-id details creation-guard)`
+- Create the token by calling `(ledger.create-token ... creation-guard)`
+   * This transaction must be signed with the keyset `creation-guard` (unrestricted signature)
+
 
 ### Mint Token
 

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -13,12 +13,20 @@
   (marmalade-v2.abc.create-account "k:creator" (read-keyset 'creator-guard))
 (commit-tx)
 
+(begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
 (begin-tx "Creating collection")
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
+    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY)} g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -47,7 +55,7 @@
 
  (expect-failure "create token fails if operator guard isn't present"
    "Keyset failure"
-   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx "Create token")
@@ -62,7 +70,7 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 
 (commit-tx)
 
@@ -104,8 +112,8 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
-  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE )
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -129,11 +137,11 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 
   (expect-failure "creating another token will exceed collection-size"
     "Exceeds collection size"
-    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx "Create collection with unlimited size and add two tokens")
@@ -142,8 +150,8 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
-  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -167,9 +175,9 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 
   (expect "create another token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 (rollback-tx)

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -6,11 +6,19 @@
 (use marmalade-v2.policy-manager [NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 (commit-tx)
 
+(begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
 (begin-tx "Create token without mint guard")
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
 })
@@ -22,7 +30,7 @@
 
 (expect "create token succeeds without mint-guard"
  true
- (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ))
+ (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) g-utils.ALWAYS-TRUE))
 
 (expect "Mint token succeeds without mint-guard"
   true
@@ -35,7 +43,7 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"mint_guard": {"keys": ["mint"], "pred": "keys-all"}
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -43,7 +51,7 @@
 
 (expect "create token succeeds with mint-guard"
  true
- (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ))
+ (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) g-utils.ALWAYS-TRUE))
 
  (env-sigs [
    { 'key: 'mint-false

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -3,6 +3,14 @@
 (typecheck "marmalade-v2.non-fungible-policy-v1")
 
 (begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
+(begin-tx)
   (use marmalade-v2.policy-manager [ NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
   (use marmalade-v2.util-v1 [concrete-policy-bool])
 
@@ -32,7 +40,7 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } )
+    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } g-utils.ALWAYS-TRUE)
     ,"account": "k:account"
     ,"nfp-mint-guard": {"keys": ["account"], "pred": "keys-all"}
     ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -43,7 +51,7 @@
 (begin-tx "Create a non-fungible token")
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
-  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) )
+  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) g-utils.ALWAYS-TRUE)
 (commit-tx)
 
 (begin-tx "Mint with a supply other then 1 fails ")

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -3,6 +3,14 @@
 (typecheck "marmalade-v2.royalty-policy-v1")
 
 (begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
+(begin-tx)
 (use marmalade-v2.policy-manager [concrete-policy concrete-policy])
 (use marmalade-v2.ledger)
 
@@ -16,7 +24,7 @@
 (use marmalade-v2.util-v1)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} g-utils.ALWAYS-TRUE)
  ,"account": "account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -50,7 +58,7 @@
 
 (expect-failure "create-token with negative royalty rate fails"
   "Invalid royalty rate"
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx)
@@ -59,7 +67,7 @@
 (use marmalade-v2.util-v1)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -72,7 +80,7 @@
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
 
 (env-sigs [
   { 'key: 'account
@@ -97,7 +105,7 @@
 (marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
 
   ,"quote":{
      "spec": {
@@ -139,7 +147,7 @@
 (env-sigs
  [{'key:'buyer
   ,'caps: [
-    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (util.to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE) "k:account" "k:buyer"  1.0 (util.to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
     (marmalade-v2.abc.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
    ]}])
 

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -69,11 +69,6 @@
     @event
   )
 
-  (defcap TOKEN:bool (id:string precision:integer supply:decimal policies:[module{kip.token-policy-v2}] uri:string)
-    @doc " Emitted when token ID is created."
-    @event
-  )
-
   (defcap ACCOUNT_GUARD:bool (id:string account:string guard:guard)
     @doc " Emitted when ACCOUNT guard is updated."
     @event
@@ -130,20 +125,6 @@
       [ (property (!= id ""))
         (property (!= account ""))
         (property (>= amount 0.0))
-      ]
-  )
-
-  (defun create-token:bool
-    ( id:string
-      precision:integer
-      uri:string
-      policies:[module{kip.token-policy-v2}]
-    )
-    @doc "Create a new token with ID, PRECISION, URI, and POLICY."
-    @model
-      [ (property (!= id ""))
-        (property (>= precision 0))
-        (property (!= uri ""))
       ]
   )
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -65,7 +65,7 @@
   (load "../test/abc.pact")
 (commit-tx)
 
-(typecheck "marmalade-v2.policy-manager")
+;(typecheck "marmalade-v2.policy-manager")
 
 (begin-tx "load concrete-polices")
   (load "../concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact")
@@ -88,10 +88,13 @@
 (use marmalade-v2.policy-manager)
 (use marmalade-v2.util-v1)
 
+(env-data { 'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}})
 (env-data {
-  "default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
- ,"reserved-token-id": (create-token-id { 'uri: "marmalade:uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
- ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-policies EMPTY) } )
+  'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}
+ ,'bad-c-ks: {"keys": ["bad-creation-guard"], "pred": "keys-all"}
+ ,"default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT)} (read-keyset 'c-ks))
+ ,"reserved-token-id": (create-token-id { 'uri: "marmalade:uri", 'precision: 0, 'policies: (create-policies DEFAULT)} (read-keyset 'c-ks))
+ ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-policies EMPTY)} (read-keyset 'c-ks))
  ,"wrong-token-protocol-id": "t:wrong"
  ,"wrong-token-id": "wrong"
  ,"account": "k:account"
@@ -103,28 +106,34 @@
    ,'caps: [(marmalade-v2.ledger.MINT (read-msg "default-token-id") "k:account" 1.0)
             (marmalade-v2.guard-policy-v1.MINT (read-msg "default-token-id") "k:account" 1.0)
             (marmalade-v2.ledger.MINT (read-msg 'empty-token-id) "k:account" 1.0)
-   ]
-   }])
+   ]},
+  { 'key: "creation-guard"
+   ,'caps: []}
+  ])
+
+(expect-failure "create a token without signing with the right creation guard"
+  "Keyset failure"
+  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-policies DEFAULT) (read-keyset 'bad-c-ks) ))
 
 (expect-failure "create a token with uri starting with marmalade fails"
   "Reserved protocol: marmalade:"
-  (create-token (read-msg 'reserved-token-id) 0 "marmalade:uri" (create-policies DEFAULT) ))
+  (create-token (read-msg 'reserved-token-id) 0 "marmalade:uri" (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
 (expect-failure "create a token with unmatching token-id"
   "Token protocol violation"
-  (create-token (read-msg 'wrong-token-protocol-id) 0 "test-uri" (create-policies DEFAULT) ))
+  (create-token (read-msg 'wrong-token-protocol-id) 0 "test-uri" (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
 (expect-failure "create a token without token protocol"
   "Unrecognized reserved protocol"
-  (create-token (read-msg 'wrong-token-id) 0 "test-uri" (create-policies DEFAULT) ))
+  (create-token (read-msg 'wrong-token-id) 0 "test-uri" (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-policies DEFAULT) ))
+  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
 (expect "create a token with no concrete-policy"
   true
-  (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-policies EMPTY) ))
+  (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-policies EMPTY) (read-keyset 'c-ks)))
 
 (expect "mint a default token with quote-policy, non-fungible-policy"
   true
@@ -137,7 +146,11 @@
 (env-sigs [
   { 'key: 'marmalade-admin
    ,'caps: []
-   }])
+   }
+  { 'key: "creation-guard"
+   ,'caps: []
+  }
+])
 
 (commit-tx)
 
@@ -146,20 +159,26 @@
 (env-sigs [
   { 'key: 'marmalade-admin
    ,'caps: []
-   }])
+   }
+  { 'key: "creation-guard"
+   ,'caps: []
+  }
+])
 (env-data {
   "ns": "marmalade-v2"
   })
   (namespace (read-msg 'ns))
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
+  (env-data { 'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}})
   (env-data {
-    'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)  } )
+    'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"},
+    'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)} (read-keyset 'c-ks) )
     })
 
   (expect  "create a token "
     true
-    (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT)  ))
+    (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
   (module non-fungible-policy-v1 GOVERNANCE
 
@@ -259,11 +278,12 @@
   (use marmalade-v2.util-v1)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}
   })
   (marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
 
   (env-data {
-      "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+      "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } (read-keyset 'c-ks) )
      ,"quote":{
         "spec": {
           "fungible": marmalade-v2.abc
@@ -290,9 +310,9 @@
   (expect "start offer by running step 0 of sale"
     "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"
     (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
-
+    (env-data { 'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}})
   (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}
-            , "token-id" : (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+            , "token-id" : (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } (read-keyset 'c-ks) )
           }
   )
 
@@ -314,6 +334,7 @@
    ,"buyer": "k:buyer"
    ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
    ,"market-guard": {"keys": ["market"], "pred": "keys-all"}
+   ,'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}
   })
 
   (marmalade-v2.abc.create-account "k:buyer" (read-keyset 'buyer-guard))
@@ -322,7 +343,7 @@
   (env-sigs
   [{'key:'buyer
     ,'caps: [
-      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } ) "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } (read-keyset 'c-ks)) "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
       (marmalade-v2.abc.TRANSFER "k:buyer" "c:DzKUkpHP-1-4XUGw1R7WLfXoWtoyICfk6hV437b_IEY" 2.0)
     ]}])
 

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -2,6 +2,14 @@
 (load "../policy-manager/policy-manager.repl")
 (typecheck "marmalade-v2.quote-manager")
 
+(begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
 (begin-tx "Sell token and payout royalties")
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
@@ -26,7 +34,7 @@
         ,'collection-policy: false
         ,'guard-policy: false
       })
-    }),
+    } g-utils.ALWAYS-TRUE),
     "quote": {
       "spec": {
         "seller-fungible-account": {
@@ -56,7 +64,7 @@
       ,'royalty-policy: true
       ,'collection-policy: false
       ,'guard-policy: false
-    })))
+    }) g-utils.ALWAYS-TRUE))
 
   (env-sigs [
     { 'key: 'seller
@@ -96,7 +104,7 @@
         ,'collection-policy: false
         ,'guard-policy: false
       })
-    })
+    } g-utils.ALWAYS-TRUE)
     ,"sale-id": "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"
     ,"buyer": "k:bidder"
     ,"buyer-guard": {"keys": ["bidder"], "pred": "keys-all"}


### PR DESCRIPTION
In this PR, I suggest:

For the poly-fungible interface, remove the `(create-token)` function and associated event:
Rationales: 
- The poly-fungible interface is supposed to be the common denominator between all ledger implementations. The objective is to make all ledgers compatible across market places and wallets. In my opinion, token creation is a special process that happens out of the usual lifetime of an NFT. It's a business between the ledger and the creator, and the API should be left implementation dependent.
- This breaks the insane link between the policy interface and the poly-fungible-interface. The poly-fungible interface does not depend anymore from the policy specification that should be left implementation dependent.
   
I suggest to change the mechanism of token-id generation. 
Rationales:
- The current mechanism uses a concatenation of the token-info object and the chain_id, to compute the token-id. The advantage of this simple mechanism is to avoid X-chain squatting. But it has two major drawbacks:
    * It makes X-chainable NFT (as we plan to do) impossible, I can't imagine the same NFT having different IDs on different chains.
    * It doesn't prevent front-running on the same chain (see https://github.com/kadena-io/marmalade/issues/114) . I still remember the mess around the coin accounts front-runned by bots before the introduction of the principals. I don't want this to happen with Marmalade as well. This is far from being irrelevant. If a moron has the idea to run such a bot for Marmalade, the project is dead. 

- I suggest to use a temporary guard (usually a keyset). This guard is concatenated to the token-info object to generate the token-id. And of course the guard is enforced during token creation.
    * The creator can generate a token ID off chain.
    * Then he can then submit the token creation. But the token creation won't work if the transaction is not signed by the keyset used to generate the token-id.
    * As a result, the token-id is fully reserved, on the same-chain (protected from front-running), but also on others chains.
    * As a conclusion: this a very simple and efficient mechanism. This can be implemented without too much pain by a token generation UX.

I updated the docs, and the REPL tests as well. Please note that in most cases I used a "always-success" creation guard to not make things unnecessarily complicated where  others features are being tested.