### PR TITLE
Check guard at WITHDRAW, minor fixes 

### DIFF
--- a/examples/basic-bidding-sale/basic-bidding-sale.repl
+++ b/examples/basic-bidding-sale/basic-bidding-sale.repl
@@ -241,7 +241,6 @@
     "token-id": (create-token-id { 'uri: "bidding-test-uri", 'precision: 0, 'policies: [] } )
     ,"buyer": "k:bidder"
     ,"buyer-guard": {"keys": ["bidder"], "pred": "keys-all"}
-    ,"buyer_fungible_account": "k:bidder"
     ,"sale-id": "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"
   })
 

--- a/examples/basic-bidding-sale/basic-bidding-sale.repl
+++ b/examples/basic-bidding-sale/basic-bidding-sale.repl
@@ -18,13 +18,13 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "bidding-test-uri", 'precision: 0, 'policies: [] } )
     ,"account": "k:account"
   })
 
   (expect "create a default token without any policies"
     true
-    (create-token (read-msg 'token-id) 0 "test-uri" [] ))
+    (create-token (read-msg 'token-id) 0 "bidding-test-uri" [] ))
 
   (env-sigs [
     { 'key: 'random
@@ -32,7 +32,7 @@
     }])
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "bidding-test-uri", 'precision: 0, 'policies: [] } )
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   })
@@ -59,7 +59,7 @@
   })
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "bidding-test-uri", 'precision: 0, 'policies: [] } )
     ,"quote": {
       "spec": {
         "seller-fungible-account": {
@@ -96,7 +96,7 @@
   })
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "bidding-test-uri", 'precision: 0, 'policies: [] } )
     ,"quote": {
       "spec": {
         "seller-fungible-account": {
@@ -156,7 +156,7 @@
   (use free.basic-bidding-sale)
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "bidding-test-uri", 'precision: 0, 'policies: [] } )
     ,"sale-id": "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"
     ,"bidder-guard": {"keys": ["bidder"], "pred": "keys-all"}
   })
@@ -238,7 +238,7 @@
   (use free.basic-bidding-sale)
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "bidding-test-uri", 'precision: 0, 'policies: [] } )
     ,"buyer": "k:bidder"
     ,"buyer-guard": {"keys": ["bidder"], "pred": "keys-all"}
     ,"buyer_fungible_account": "k:bidder"

--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -492,13 +492,19 @@
     (id:string seller:string amount:decimal timeout:decimal sale-id:string)
     @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after timeout."
     @managed
+    (compose-capability (SALE_PRIVATE sale-id))
     (enforce-one "WITHDRAW: still active" [
       (enforce (= 0.0 timeout) "No timeout set")
       (enforce (not (sale-active timeout)) "WITHDRAW: still active")
     ])
+    (if (= 0.0 timeout)
+      ;; check seller guard
+      (enforce-guard (at 'guard (details id seller)))
+      ;; skip
+      true
+    )
     (compose-capability (DEBIT id (sale-account)))
     (compose-capability (CREDIT id seller))
-    (compose-capability (SALE_PRIVATE sale-id))
   )
 
   (defcap BUY:bool

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -67,4 +67,9 @@
      ,'guard-policy: (contains (get-concrete-policy GUARD_POLICY) policies)
     }
   )
+  
+  (defun to-timestamp:decimal (input:time)
+    "Computes an Unix timestamp of the input date"
+    (diff-time input (time "1970-01-01T00:00:00Z"))
+  )
 )

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -66,7 +66,7 @@
   (load "./test/abc.pact")
 (commit-tx)
 
-(typecheck "marmalade-v2.policy-manager")
+(typecheck "marmalade-v2.ledger")
 
 (begin-tx "load concrete-polices")
   (load "./concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact")
@@ -221,7 +221,7 @@
     (get-balance (read-string "token-id") (read-string "account"))
   )
 
-  (expect "Escrow account is debited"
+  (expect "Escrow account is credited"
     1.0
     (get-balance (read-string "token-id") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc")
   )
@@ -235,7 +235,21 @@
     (map (remove "module-hash")  (env-events true))
   )
 
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
+  ])
+
+  (env-chain-data {"block-time": (time "2023-07-21T11:26:35Z")})
+
+  (expect-failure "withdraw fails before timeout has passed"
+    "WITHDRAW: still active"
+    (continue-pact 0 true)
+  )
+
   (env-chain-data {"block-time": (time "2023-07-23T11:26:35Z")})
+
+  (env-sigs [])
 
   (expect-failure "withdraw fails when called directly"
     "require-capability: not granted: (marmalade-v2.ledger.SALE_PRIVATE"
@@ -266,7 +280,7 @@
 
 (rollback-tx)
 
-(begin-tx "offer, withdraw with timeout")
+(begin-tx "offer, withdraw without timeout")
 
 (env-hash (hash "offer-1"))
 (use marmalade-v2.ledger)
@@ -287,7 +301,7 @@
   (get-balance (read-string "token-id") (read-string "account"))
 )
 
-(expect "Escrow account is debited"
+(expect "Escrow account is credited"
   1.0
   (get-balance (read-string "token-id") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q")
 )

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -1,2 +1,263 @@
-(load "./policy-manager/policy-manager.repl")
-(typecheck "marmalade-v2.ledger")
+(begin-tx)
+  (env-data
+    { 'ns-admin-keyset: []
+    , 'ns-genesis-keyset:[]
+    , 'ns-operate-keyset:[] })
+  (load "./root/fungible-v2.pact")
+  (load "./root/fungible-xchain-v1.pact")
+  (load "./root/gas-payer-v1.pact")
+  (env-exec-config ["DisablePact44"])
+  (load "./root/ns.pact")
+  (define-namespace 'kip (sig-keyset) (sig-keyset))
+
+  (load "./kip/account-protocols-v1.pact")
+  (env-data
+  { 'marmalade-admin: ["marmalade-admin"]
+  , 'marmalade-ns-user: ["marmalade-admin"]
+  , 'marmalade-ns-admin: ["marmalade-admin"]
+  , 'ns: "marmalade-v2"
+  , 'upgrade: false })
+
+  (load "./kip/manifest.pact")
+  (load "./kip/token-policy-v2.pact")
+  (load "./kip/poly-fungible-v3.pact")
+  (define-namespace 'util (sig-keyset) (sig-keyset))
+  (load "./util/fungible-util.pact")
+  (load "./util/guards1.pact")
+
+(commit-tx)
+
+;; todo: move this to a util lib
+(begin-tx)
+  (module util GOVERNANCE
+    (defcap GOVERNANCE ()
+      false)
+
+    (defun to-timestamp:decimal (input:time)
+      "Computes an Unix timestamp of the input date"
+      (diff-time input (time "1970-01-01T00:00:00Z"))
+    )
+  )
+(commit-tx)
+
+(begin-tx)
+  (env-data
+   { 'marmalade-admin: ["marmalade-admin"]
+   , "marmalade-v2.marmalade-admin": ["marmalade-admin"]
+   , 'marmalade-ns-user: ["marmalade-admin"]
+   , 'marmalade-ns-admin: ["marmalade-admin"]
+   , 'ns: "marmalade-v2"
+   , 'upgrade: false })
+   (env-sigs [
+     { 'key: 'marmalade-admin
+      ,'caps: []
+      }])
+  (load "./ns-marmalade.pact")
+  (env-data
+   { 'marmalade-admin: ["marmalade-admin"]
+   , 'marmalade-ns-user: ["marmalade-admin"]
+   , 'marmalade-ns-admin: ["marmalade-admin"]
+   , 'ns: "marmalade-v2"
+   , 'upgrade: false })
+  (load "./quote-manager/quote-manager.pact")
+  (load "./policy-manager/policy-manager.pact")
+  (load "./ledger.pact")
+  (load "./marmalade-util/util-v1.pact")
+  (load "./test/abc.pact")
+(commit-tx)
+
+(typecheck "marmalade-v2.policy-manager")
+
+(begin-tx "load concrete-polices")
+  (load "./concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact")
+  (load "./concrete-policies/royalty-policy/royalty-policy-v1.pact")
+  (load "./concrete-policies/collection-policy/collection-policy-v1.pact")
+  (load "./concrete-policies/guard-policy/guard-policy-v1.pact")
+  (load "./policy-manager/manager-init.pact")
+(commit-tx)
+
+(begin-tx "load regular policies")
+  (load "./policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact")
+  (load "./policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact")
+(commit-tx)
+
+(begin-tx "create-token")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (env-chain-data {"chain-id": "0"})
+
+  (expect-failure "create a token with token-id with a protocol other than t:"
+    "Unrecognized reserved protocol"
+    (create-token "a:bc" 0 "test-uri" [] ))
+
+  (expect-failure "create a token with token-id not using a protocol"
+    "Unrecognized reserved protocol"
+    (create-token "abc" 0 "test-uri" [] ))
+
+  (expect-failure "create a token with token-id that doesn't satisfy t: protocol"
+    "Token protocol violation"
+    (create-token
+      (create-token-id { 'uri: "test-uri-wrong", 'precision: 0, 'policies: [] } )
+      0 "test-uri" [] ))
+
+  (expect-failure "create a token with uri starting with marmalade fails"
+    "Reserved protocol: marmalade:"
+    (create-token
+      (create-token-id { 'uri: "marmalade:uri", 'precision: 0, 'policies: [] } )
+       0 "marmalade:uri" [] ))
+
+  (expect "create a token with token-id that satisfies t: protocol"
+    true
+    (create-token
+      (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+       0 "test-uri" []))
+
+  (expect "Token info is inserted into table"
+    { "id": "t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4"
+     ,"supply": 0.0
+     ,"precision": 0
+     ,"uri": "test-uri"
+     ,"policies": []
+    }
+    (get-token-info "t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4")
+  )
+
+  (expect "create-token events"
+     (format "{}" [[{"name": "marmalade-v2.ledger.TOKEN","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" 0 0.0 [] "test-uri"]}]])
+     (format "{}" [(map (remove "module-hash")  (env-events true))])
+  )
+
+(commit-tx)
+
+(begin-tx "mint")
+  (use marmalade-v2.ledger)
+
+  (env-data {
+     "token-id": "t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4"
+    ,"account": "k:account"
+    ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+    })
+
+  (expect-failure "mint fails without MINT capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.MINT"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard) 1.0))
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(MINT (read-msg "token-id") "k:account" 1.0)]}
+   ])
+
+  (expect "mint succeeds"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard) 1.0))
+
+  (expect "Token supply is updated"
+    { "id": (read-string "token-id")
+     ,"supply": 1.0
+     ,"precision": 0
+     ,"uri": "test-uri"
+     ,"policies": []
+    }
+    (get-token-info (read-string "token-id"))
+  )
+
+  (expect "Account is credited"
+    1.0
+    (get-balance (read-string "token-id") (read-string "account"))
+  )
+
+  (expect "mint events"
+    [
+      {"name": "marmalade-v2.ledger.MINT","params": [(read-string "token-id") (read-string "account") 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") (read-string "account") (read-keyset "account-guard")]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}
+      {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-string "token-id") 1.0]}
+    ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "offer, withdraw")
+  (env-hash (hash "offer-0"))
+  (use marmalade-v2.ledger)
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+  (env-data {
+     "token-id": "t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4"
+    ,"account": "k:account"
+    ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+    })
+
+  (expect-failure "offer fails when called directly"
+    "pact-id: not in pact execution"
+    (offer (read-string "token-id") (read-string "account") 1.0)
+  )
+
+  (expect-failure "offer fails without OFFER capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.OFFER"
+    (sale (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]}
+  ])
+
+  (expect-failure "offer fails if OFFER capability is not signed by seller"
+    "Keyset failure (keys-all): [account]"
+    (sale (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (env-sigs [
+    { 'key: 'account
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]}
+  ])
+
+  (expect "offer succeeds"
+    (pact-id)
+    (sale (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (expect "Seller account is debited"
+    0.0
+    (get-balance (read-string "token-id") (read-string "account"))
+  )
+
+  (expect "Escrow account is debited"
+    1.0
+    (get-balance (read-string "token-id") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc")
+  )
+
+  (expect "offer events"
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 1690025195.0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 1690025195.0 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string "account") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string "account"),"current": 0.0,"previous": 1.0} {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-chain-data {"block-time": (time "2023-07-23T11:26:35Z")})
+
+  (expect-failure "withdraw fails when called directly"
+    "require-capability: not granted: (marmalade-v2.ledger.SALE_PRIVATE"
+    (withdraw (read-string "token-id") (read-string "account") 1.0)
+  )
+
+  (expect-failure "withdraw fails without WITHDRAW capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.WITHDRAW"
+    (continue-pact 0 true)
+  )
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
+  ])
+
+  (expect-failure "withdraw fails without WITHDRAW capability in scope"
+    (continue-pact 0 true)
+  )
+
+(commit-tx)

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -76,11 +76,6 @@
   (load "./policy-manager/manager-init.pact")
 (commit-tx)
 
-(begin-tx "load regular policies")
-  (load "./policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact")
-  (load "./policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact")
-(commit-tx)
-
 (begin-tx "create-token")
 
   (use marmalade-v2.ledger)
@@ -348,3 +343,6 @@
 )
 
 (rollback-tx)
+
+(begin-tx "test utility functions")
+(commit-tx)

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -27,19 +27,6 @@
 
 (commit-tx)
 
-;; todo: move this to a util lib
-(begin-tx)
-  (module util GOVERNANCE
-    (defcap GOVERNANCE ()
-      false)
-
-    (defun to-timestamp:decimal (input:time)
-      "Computes an Unix timestamp of the input date"
-      (diff-time input (time "1970-01-01T00:00:00Z"))
-    )
-  )
-(commit-tx)
-
 (begin-tx)
   (env-data
    { 'marmalade-admin: ["marmalade-admin"]
@@ -178,6 +165,7 @@
 (begin-tx "offer, withdraw with timeout")
   (env-hash (hash "offer-0"))
   (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
 
   (env-data {
@@ -193,27 +181,27 @@
 
   (expect-failure "offer fails without OFFER capability in scope"
     "Managed capability not installed: (marmalade-v2.ledger.OFFER"
-    (sale (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
   )
 
   (env-sigs [
     { 'key: 'any
-     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]}
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))]}
   ])
 
   (expect-failure "offer fails if OFFER capability is not signed by seller"
     "Keyset failure (keys-all): [account]"
-    (sale (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
   )
 
   (env-sigs [
     { 'key: 'account
-     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]}
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))]}
   ])
 
   (expect "offer succeeds"
     (pact-id)
-    (sale (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
   )
 
   (expect "Seller account is debited"
@@ -237,7 +225,7 @@
 
   (env-sigs [
     { 'key: 'any
-     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
   ])
 
   (env-chain-data {"block-time": (time "2023-07-21T11:26:35Z")})
@@ -263,7 +251,7 @@
 
   (env-sigs [
     { 'key: 'any
-     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
   ])
 
   (expect "withdraw succeeds when WITHDRAW capability in scope, regardless of signer"

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -124,7 +124,8 @@
   )
 
   (expect "create-token events"
-     (format "{}" [[{"name": "marmalade-v2.ledger.TOKEN","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" 0 0.0 [] "test-uri"]}]])
+     (format "{}" [[
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" 0 0.0 [] "test-uri"]}]])
      (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 
@@ -179,7 +180,7 @@
 
 (commit-tx)
 
-(begin-tx "offer, withdraw")
+(begin-tx "offer, withdraw with timeout")
   (env-hash (hash "offer-0"))
   (use marmalade-v2.ledger)
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
@@ -256,8 +257,94 @@
      ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
   ])
 
-  (expect-failure "withdraw fails without WITHDRAW capability in scope"
+  (expect "withdraw succeeds when WITHDRAW capability in scope, regardless of signer"
+    (pact-id)
     (continue-pact 0 true)
   )
 
-(commit-tx)
+  (expect "withdraw events"
+    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "k:account" 1.0 1690025195.0 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" 1.0 {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(rollback-tx)
+
+(begin-tx "offer, withdraw with timeout")
+
+(env-hash (hash "offer-1"))
+(use marmalade-v2.ledger)
+(env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+(env-sigs [
+  { 'key: 'account
+   ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 0.0)]}
+])
+
+(expect "offer succeeds"
+  (pact-id)
+  (sale (read-string "token-id") (read-string "account") 1.0 0.0)
+)
+
+(expect "Seller account is debited"
+  0.0
+  (get-balance (read-string "token-id") (read-string "account"))
+)
+
+(expect "Escrow account is debited"
+  1.0
+  (get-balance (read-string "token-id") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q")
+)
+
+(expect "offer events"
+  [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 0.0]}
+    {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 0.0 (pact-id)]}
+    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" (create-capability-pact-guard (SALE_PRIVATE (pact-id)))]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string "account") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string "account"),"current": 0.0,"previous": 1.0} {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 1.0,"previous": 0.0}]}]
+  (map (remove "module-hash")  (env-events true))
+)
+
+(env-chain-data {"block-time": (time "2023-07-25T11:26:35Z")})
+
+(expect-failure "withdraw fails when called directly"
+  "require-capability: not granted: (marmalade-v2.ledger.SALE_PRIVATE"
+  (withdraw (read-string "token-id") (read-string "account") 1.0)
+)
+
+(expect-failure "withdraw fails without WITHDRAW capability in scope"
+  "Managed capability not installed: (marmalade-v2.ledger.WITHDRAW"
+  (continue-pact 0 true)
+)
+
+(env-sigs [
+  { 'key: 'any
+   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0.0 (pact-id))]}
+])
+
+(expect-failure "withdraw fails when sig is not signed"
+  "Keyset failure (keys-all): "
+  (continue-pact 0 true)
+)
+
+(env-sigs [
+  { 'key: 'account
+   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0.0 (pact-id))]}
+])
+
+(expect "withdraw succeeds"
+  (pact-id)
+  (continue-pact 0 true)
+)
+
+(expect "withdraw events"
+  [
+    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "k:account" 1.0 0.0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" "k:account" 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" 1.0 {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}
+  ]}]
+  (map (remove "module-hash")  (env-events true))
+)
+
+(rollback-tx)

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -202,14 +202,12 @@
     (with-capability (POLICY_MANAGER)
 
     (if (exists-quote sale-id)
-      [
-        (let* (
-          (quote (get-quote-info sale-id))
-          (reserved (at 'reserved quote)))
-          (enforce (= "" reserved) "Sale is reserved, unable to withdraw")
-          (let ((_ ""))(map-withdraw token seller amount sale-id (at 'policies token)) true)
-        )
-      ]
+      (let* (
+        (quote (get-quote-info sale-id))
+        (reserved (at 'reserved quote)))
+        (enforce (= "" reserved) "Sale is reserved, unable to withdraw")
+        (map-withdraw token seller amount sale-id (at 'policies token))
+      )
       ; quote is not used
       (map-withdraw token seller amount sale-id (at 'policies token))
     )))

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -207,7 +207,7 @@
           (quote (get-quote-info sale-id))
           (reserved (at 'reserved quote)))
           (enforce (= "" reserved) "Sale is reserved, unable to withdraw")
-          (map-withdraw token seller amount sale-id (at 'policies token))
+          (let ((_ true))(map-withdraw token seller amount sale-id (at 'policies token)) true)
         )
       ]
       ; quote is not used
@@ -326,7 +326,6 @@
            (reserved-buyer:string (at 'reserved quote))
            (spec:object{quote-spec} (at 'spec quote))
            (fungible:module{fungible-v2} (at 'fungible spec))
-           (buyer-fungible-account-name:string (read-msg BUYER-FUNGIBLE-ACCOUNT-MSG-KEY))
            (seller-fungible-account:object{fungible-account} (at 'seller-fungible-account spec))
            (price:decimal (at 'price spec))
            (sale-price:decimal (floor (* price amount) (fungible::precision)))
@@ -334,7 +333,7 @@
 
        (if (= reserved-buyer "")
         ; No reserved buyer, transfer from buyer to escrow
-        (fungible::transfer-create buyer-fungible-account-name (at 'account escrow-account) (at 'guard escrow-account) sale-price)
+        (fungible::transfer-create (read-msg BUYER-FUNGIBLE-ACCOUNT-MSG-KEY) (at 'account escrow-account) (at 'guard escrow-account) sale-price)
         ; Reserved buyer, escrow has already been funded
         (enforce (= reserved-buyer buyer) "Reserved buyer must be buyer")
        )

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -207,7 +207,7 @@
           (quote (get-quote-info sale-id))
           (reserved (at 'reserved quote)))
           (enforce (= "" reserved) "Sale is reserved, unable to withdraw")
-          (let ((_ true))(map-withdraw token seller amount sale-id (at 'policies token)) true)
+          (let ((_ ""))(map-withdraw token seller amount sale-id (at 'policies token)) true)
         )
       ]
       ; quote is not used

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -10,15 +10,16 @@
    (use marmalade-v2.ledger)
    (use marmalade-v2.util-v1)
 
-  (env-data {
-    'ns: "marmalade-v2"
-   ,'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)  } )
+   (env-data {
+     'ns: "marmalade-v2"
+    ,'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)  } )
     })
+
     (namespace (read-msg 'ns))
 
     (expect  "create a token "
       true
-      (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT)  ))
+      (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT) ))
 
     (module non-fungible-policy-v1 GOVERNANCE
 
@@ -119,7 +120,6 @@
 
   (env-hash (hash "offer-1"))
   (env-chain-data {"chain-id": "0"})
-
   (env-data {
     "mint-guard": {"keys": ["mint"], "pred": "keys-all"}
     })
@@ -127,36 +127,34 @@
   (expect-failure "enforce-init cannot be called directly"
     "Capability not acquired"
     (enforce-init {
-      "id": (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+      "id": (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: [] } )
      ,"supply": 0.0
      ,"precision": 0
      ,"uri": "default-test-uri"
-     ,"policies": (create-policies DEFAULT) })
+     ,"policies": [] })
   )
 
   (expect "create a token"
     true
     (create-token
-      (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
-       0 "default-test-uri" (create-policies DEFAULT)))
+      (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: [] } )
+       0 "default-test-uri" []))
 
   (expect "create-token events"
-     [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [{"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
-       {"name": "marmalade-v2.ledger.TOKEN","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 0 0.0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "default-test-uri"]}
-     ]
+     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 0 0.0 [] "default-test-uri"]}]
      (map (remove "module-hash")  (env-events true))
   )
 
 (commit-tx)
 
 (begin-tx "Test enforce-mint")
-
+  (env-chain-data {"chain-id": "0"})
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
 
   (env-data {
-     "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+     "token-id": "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U"
     , "account": "k:account"
     , "account-guard": {"keys": ["account"], "pred": "keys-all"}
     })
@@ -170,7 +168,7 @@
 
    (expect-failure "enforce-mint cannot be called directly"
      "Capability not acquired"
-     (enforce-mint (get-token-info "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo") (read-string 'account) (read-keyset 'account-guard ) 1.0)
+     (enforce-mint (get-token-info "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U") (read-string 'account) (read-keyset 'account-guard ) 1.0)
    )
 
   (expect "mint a default token through ledger.mint"
@@ -178,9 +176,9 @@
     (mint (read-string 'token-id )  (read-string 'account ) (read-keyset 'account-guard ) 1.0))
 
   (expect "mint events"
-    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" (read-keyset 'account-guard)]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0]}
+    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0]}
     ]
    (map (remove "module-hash")  (env-events true))
   )
@@ -192,13 +190,14 @@
 (rollback-tx)
 
 (begin-tx "Test enforce-offer, enforce-withdraw(fail), enforce-buy(succeed) without quote")
+  (env-chain-data {"chain-id": "0"})
   (env-hash (hash "enforce-offer-0"))
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
 
   (env-data {
-      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+      "token-id": "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U"
      ,"seller": "k:account"
   })
 
@@ -229,12 +228,12 @@
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
       ]}
   ])
 
   (env-data {
-    "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+    "token-id": "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U"
    ,"seller": "k:account"
    ,"buyer": "k:buyer"
    ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
@@ -249,10 +248,10 @@
     (continue-pact 1))
 
   (expect "buy events"
-   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
-     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:buyer" (read-keyset 'buyer-guard)]}
-     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
-     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:buyer" (read-keyset 'buyer-guard)]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
@@ -270,13 +269,14 @@
 
 
 (begin-tx "Test enforce-offer, enforce-withdraw (succeed), enforce-buy (fail) without quote")
+  (env-chain-data {"chain-id": "0"})
   (env-hash (hash "enforce-offer-1"))
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
 
   (env-data {
-      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+      "token-id": "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U"
      ,"seller": "k:account"
   })
 
@@ -314,21 +314,21 @@
     (continue-pact 0 true))
 
   (expect "withdraw events"
-   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
-     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
       ]}
   ])
 
   (env-data {
-    "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+    "token-id": "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U"
    ,"seller": "k:account"
    ,"buyer": "k:buyer"
    ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
@@ -341,7 +341,7 @@
 (rollback-tx)
 
 (begin-tx "Create buyer and market fungible account, fund buyer account")
-
+  (env-chain-data {"chain-id": "0"})
   (env-data {
     "buyer-guard": {"keys": ["buyer-fungible"], "pred": "keys-all"}
    ,"market-guard": {"keys": ["market-fungible"], "pred": "keys-all"}
@@ -354,7 +354,7 @@
 (commit-tx)
 
 (begin-tx "Test enforce-offer, enforce-withdraw(succeeds), enforce-buy(fails) with quote and without reserved sale")
-
+  (env-chain-data {"chain-id": "0"})
   (env-hash (hash "enforce-offer-1"))
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
@@ -368,7 +368,7 @@
   (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
 
   (env-data {
-      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+      "token-id": "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U"
      ,"seller": "k:account"
      ,"quote":{
         "spec": {
@@ -411,7 +411,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 (pact-id))]
     }])
 
   (expect "Withdraw succeeds"
@@ -419,9 +419,9 @@
     (continue-pact 0 true))
 
     (expect "withdraw events"
-      [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-        {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
-        {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+      [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
       (map (remove "module-hash")  (env-events true))
     )
 
@@ -432,7 +432,7 @@
       ]}
     {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
       ]}
   ])
 
@@ -449,7 +449,7 @@
 (rollback-tx)
 
 (begin-tx "Test enforce-offer, enforce-withdraw(fails), enforce-buy(succeeds) with quote and without reserved sale")
-
+  (env-chain-data {"chain-id": "0"})
   (env-hash (hash "enforce-offer-1"))
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
@@ -463,7 +463,7 @@
   (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
 
   (env-data {
-      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+      "token-id": "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U"
      ,"seller": "k:account"
      ,"quote":{
         "spec": {
@@ -516,7 +516,7 @@
        ]}
      {'key:'buyer
        ,'caps: [
-         (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+         (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
        ]}
    ])
 
@@ -527,17 +527,17 @@
   (expect "buy events"
     [ {"name": "marmalade-v2.abc.TRANSFER","params": ["k:buyer-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 2.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:buyer" (read-keyset 'buyer-guard)]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 (pact-id))]
     }])
 
   (expect-failure "Withdraw fails after buy has completed"
@@ -548,7 +548,7 @@
 
 
 (begin-tx "Test enforce-offer, enforce-withdraw, enforce-buy with quote and reserved sale")
-
+  (env-chain-data {"chain-id": "0"})
   (env-hash (hash "enforce-offer-1"))
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
@@ -562,7 +562,7 @@
   (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
 
   (env-data {
-      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+      "token-id": "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U"
      ,"seller": "k:account"
      ,"quote":{
         "spec": {
@@ -622,7 +622,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 (pact-id))]
     }])
 
   (expect-failure "Withdraw fails when a sale is reserved"
@@ -632,7 +632,7 @@
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
       ]}
   ])
 
@@ -659,10 +659,10 @@
       {"name": "marmalade-v2.abc.TRANSFER","params": ["k:market-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.0]}
       {"name": "marmalade-v2.policy-manager.SALE_RESERVED","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 1.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:buyer" (read-keyset 'buyer-guard)]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -27,6 +27,7 @@
 
 (commit-tx)
 
+;; todo: move this to a util lib
 (begin-tx)
   (module util GOVERNANCE
     (defcap GOVERNANCE ()
@@ -75,11 +76,10 @@
   (load "./manager-init.pact")
 (commit-tx)
 
-(begin-tx "load regular polices")
+(begin-tx "load regular policies")
   (load "../policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact")
   (load "../policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact")
   ; (load "../policies/migration-policy/migration-policy-v1.pact")
-
 (commit-tx)
 
 (begin-tx)

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -162,7 +162,7 @@
 (env-sigs [
   { 'key: 'mint
    ,'caps: [(marmalade-v2.ledger.MINT (read-msg "token-id") "k:account" 1.0)
-            (marmalade-v2.guard-policy-v1.MINT (read-string "token-id") "k:account" 1.0)
+            ; (marmalade-v2.guard-policy-v1.MINT (read-string "token-id") "k:account" 1.0)
    ]
    }])
 
@@ -186,7 +186,25 @@
 (commit-tx)
 
 (begin-tx "Test enforce-burn")
-;;TODO
+(use marmalade-v2.ledger)
+(use marmalade-v2.policy-manager)
+(use marmalade-v2.util-v1)
+
+(env-sigs [
+  { 'key: 'account
+  ,'caps: [(marmalade-v2.ledger.BURN (read-msg "token-id") "k:account" 1.0)]
+  }])
+
+(expect-failure "enforce-burn cannot be called directly"
+ "Capability not acquired"
+ (enforce-burn (get-token-info "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U") (read-string 'account) 1.0)
+)
+
+(expect "enforce-burn cannot be called directly"
+  true
+  (burn "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" (read-string 'account) 1.0)
+)
+
 (rollback-tx)
 
 (begin-tx "Test enforce-offer, enforce-withdraw(fail), enforce-buy(succeed) without quote")

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -1,241 +1,102 @@
-(begin-tx)
-  (env-data
-    { 'ns-admin-keyset: []
-    , 'ns-genesis-keyset:[]
-    , 'ns-operate-keyset:[] })
-  (load "../root/fungible-v2.pact")
-  (load "../root/fungible-xchain-v1.pact")
-  (load "../root/gas-payer-v1.pact")
-  (env-exec-config ["DisablePact44"])
-  (load "../root/ns.pact")
-  (define-namespace 'kip (sig-keyset) (sig-keyset))
-
-  (load "../kip/account-protocols-v1.pact")
-  (env-data
-  { 'marmalade-admin: ["marmalade-admin"]
-  , 'marmalade-ns-user: ["marmalade-admin"]
-  , 'marmalade-ns-admin: ["marmalade-admin"]
-  , 'ns: "marmalade-v2"
-  , 'upgrade: false })
-
-  (load "../kip/manifest.pact")
-  (load "../kip/token-policy-v2.pact")
-  (load "../kip/poly-fungible-v3.pact")
-  (define-namespace 'util (sig-keyset) (sig-keyset))
-  (load "../util/fungible-util.pact")
-  (load "../util/guards1.pact")
-
-(commit-tx)
-
-;; todo: move this to a util lib
-(begin-tx)
-  (module util GOVERNANCE
-    (defcap GOVERNANCE ()
-      false)
-
-    (defun to-timestamp:decimal (input:time)
-      "Computes an Unix timestamp of the input date"
-      (diff-time input (time "1970-01-01T00:00:00Z"))
-    )
-  )
-(commit-tx)
-
-(begin-tx)
-  (env-data
-   { 'marmalade-admin: ["marmalade-admin"]
-   , "marmalade-v2.marmalade-admin": ["marmalade-admin"]
-   , 'marmalade-ns-user: ["marmalade-admin"]
-   , 'marmalade-ns-admin: ["marmalade-admin"]
-   , 'ns: "marmalade-v2"
-   , 'upgrade: false })
-   (env-sigs [
-     { 'key: 'marmalade-admin
-      ,'caps: []
-      }])
-  (load "../ns-marmalade.pact")
-  (env-data
-   { 'marmalade-admin: ["marmalade-admin"]
-   , 'marmalade-ns-user: ["marmalade-admin"]
-   , 'marmalade-ns-admin: ["marmalade-admin"]
-   , 'ns: "marmalade-v2"
-   , 'upgrade: false })
-  (load "../quote-manager/quote-manager.pact")
-  (load "../policy-manager/policy-manager.pact")
-  (load "../ledger.pact")
-  (load "../marmalade-util/util-v1.pact")
-  (load "../test/abc.pact")
-(commit-tx)
+(load "../marmalade.repl")
 
 (typecheck "marmalade-v2.policy-manager")
 
-(begin-tx "load concrete-polices")
-  (load "../concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact")
-  (load "../concrete-policies/royalty-policy/royalty-policy-v1.pact")
-  (load "../concrete-policies/collection-policy/collection-policy-v1.pact")
-  (load "../concrete-policies/guard-policy/guard-policy-v1.pact")
-  (load "./manager-init.pact")
-(commit-tx)
 
-(begin-tx "load regular policies")
-  (load "../policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact")
-  (load "../policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact")
-  ; (load "../policies/migration-policy/migration-policy-v1.pact")
-(commit-tx)
 
-(begin-tx)
-
-(use marmalade-v2.ledger)
-(use marmalade-v2.policy-manager)
-(use marmalade-v2.util-v1)
-
-(env-data {
-  "default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
- ,"reserved-token-id": (create-token-id { 'uri: "marmalade:uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
- ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-policies EMPTY) } )
- ,"wrong-token-protocol-id": "t:wrong"
- ,"wrong-token-id": "wrong"
- ,"account": "k:account"
- ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
-  })
-
-(env-sigs [
-  { 'key: 'account
-   ,'caps: [(marmalade-v2.ledger.MINT (read-msg "default-token-id") "k:account" 1.0)
-            (marmalade-v2.guard-policy-v1.MINT (read-msg "default-token-id") "k:account" 1.0)
-            (marmalade-v2.ledger.MINT (read-msg 'empty-token-id) "k:account" 1.0)
-   ]
+(begin-tx "upgrade policy and check if stored policy matches with saved concrete policy")
+  (env-sigs [
+    { 'key: 'marmalade-admin
+     ,'caps: []
    }])
+   (use marmalade-v2.ledger)
+   (use marmalade-v2.util-v1)
 
-(expect-failure "create a token with uri starting with marmalade fails"
-  "Reserved protocol: marmalade:"
-  (create-token (read-msg 'reserved-token-id) 0 "marmalade:uri" (create-policies DEFAULT) ))
-
-(expect-failure "create a token with unmatching token-id"
-  "Token protocol violation"
-  (create-token (read-msg 'wrong-token-protocol-id) 0 "test-uri" (create-policies DEFAULT) ))
-
-(expect-failure "create a token without token protocol"
-  "Unrecognized reserved protocol"
-  (create-token (read-msg 'wrong-token-id) 0 "test-uri" (create-policies DEFAULT) ))
-
-(expect "create a default token with quote-policy, non-fungible-policy"
-  true
-  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-policies DEFAULT) ))
-
-(expect "create a token with no concrete-policy"
-  true
-  (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-policies EMPTY) ))
-
-(expect "mint a default token with quote-policy, non-fungible-policy"
-  true
-  (mint (read-msg 'default-token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))
-
-(expect "mint an empty token with no policy"
-  true
-  (mint (read-msg 'empty-token-id )  (read-msg 'account ) (read-keyset 'mint-guard ) 1.0))
-
-(env-sigs [
-  { 'key: 'marmalade-admin
-   ,'caps: []
-   }])
-
-(commit-tx)
-
-
-(begin-tx)
-(env-sigs [
-  { 'key: 'marmalade-admin
-   ,'caps: []
-   }])
-(env-data {
-  "ns": "marmalade-v2"
-  })
-  (namespace (read-msg 'ns))
-  (use marmalade-v2.ledger)
-  (use marmalade-v2.util-v1)
   (env-data {
-    'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)  } )
+    'ns: "marmalade-v2"
+   ,'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)  } )
     })
+    (namespace (read-msg 'ns))
 
-  (expect  "create a token "
-    true
-    (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT)  ))
-
-  (module non-fungible-policy-v1 GOVERNANCE
-
-    @doc "Concrete policy for issuing an nft with a fixed supply of 1"
-
-    (defcap GOVERNANCE ()
-      (enforce-guard (keyset-ref-guard 'marmalade-admin )))
-
-    (implements kip.token-policy-v2)
-    (use kip.token-policy-v2 [token-info])
-
-    (defun enforce-ledger:bool ()
-       (enforce-guard (marmalade-v2.ledger.ledger-guard))
-    )
-
-    (defun enforce-init:bool
-      ( token:object{token-info}
-      )
-      (enforce-ledger)
+    (expect  "create a token "
       true
-    )
+      (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT)  ))
 
-    (defun enforce-mint:bool
-      ( token:object{token-info}
-        account:string
-        guard:guard
-        amount:decimal
+    (module non-fungible-policy-v1 GOVERNANCE
+
+      @doc "Concrete policy for issuing an nft with a fixed supply of 1"
+
+      (defcap GOVERNANCE ()
+        (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+
+      (implements kip.token-policy-v2)
+      (use kip.token-policy-v2 [token-info])
+
+      (defun enforce-ledger:bool ()
+         (enforce-guard (marmalade-v2.ledger.ledger-guard))
       )
-      (enforce-ledger)
-    )
 
-    (defun enforce-burn:bool
-      ( token:object{token-info}
-        account:string
-        amount:decimal
+      (defun enforce-init:bool
+        ( token:object{token-info}
+        )
+        (enforce-ledger)
+        true
       )
-      (enforce-ledger)
-    )
 
-    (defun enforce-offer:bool
-      ( token:object{token-info}
-        seller:string
-        amount:decimal
-        sale-id:string
+      (defun enforce-mint:bool
+        ( token:object{token-info}
+          account:string
+          guard:guard
+          amount:decimal
+        )
+        (enforce-ledger)
       )
-      @doc "Capture quote spec for SALE of TOKEN from message"
-      (enforce-ledger)
-    )
 
-    (defun enforce-buy:bool
-      ( token:object{token-info}
-        seller:string
-        buyer:string
-        buyer-guard:guard
-        amount:decimal
-        sale-id:string )
-      (enforce-ledger)
-    )
+      (defun enforce-burn:bool
+        ( token:object{token-info}
+          account:string
+          amount:decimal
+        )
+        (enforce-ledger)
+      )
 
-    (defun enforce-transfer:bool
-      ( token:object{token-info}
-        sender:string
-        guard:guard
-        receiver:string
-        amount:decimal )
-      (enforce-ledger)
-    )
+      (defun enforce-offer:bool
+        ( token:object{token-info}
+          seller:string
+          amount:decimal
+          sale-id:string
+        )
+        @doc "Capture quote spec for SALE of TOKEN from message"
+        (enforce-ledger)
+      )
 
-    (defun enforce-withdraw:bool
-      ( token:object{token-info}
-        seller:string
-        amount:decimal
-        sale-id:string )
-      (enforce-ledger)
+      (defun enforce-buy:bool
+        ( token:object{token-info}
+          seller:string
+          buyer:string
+          buyer-guard:guard
+          amount:decimal
+          sale-id:string )
+        (enforce-ledger)
+      )
+
+      (defun enforce-transfer:bool
+        ( token:object{token-info}
+          sender:string
+          guard:guard
+          receiver:string
+          amount:decimal )
+        (enforce-ledger)
+      )
+
+      (defun enforce-withdraw:bool
+        ( token:object{token-info}
+          seller:string
+          amount:decimal
+          sale-id:string )
+        (enforce-ledger)
+      )
     )
-  )
 
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.policy-manager [NON_FUNGIBLE_POLICY])
@@ -252,26 +113,196 @@
 
 (rollback-tx)
 
-(begin-tx "start an offer")
-  (env-hash (hash "offer-0"))
+(begin-tx "Test enforce-init")
+
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
-  (env-data {
-    "seller-guard": {"keys": ["account"], "pred": "keys-all"}
-  })
-  (marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
+
+  (env-hash (hash "offer-1"))
+  (env-chain-data {"chain-id": "0"})
 
   (env-data {
-      "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+    "mint-guard": {"keys": ["mint"], "pred": "keys-all"}
+    })
+
+  (expect-failure "enforce-init cannot be called directly"
+    "Capability not acquired"
+    (enforce-init {
+      "id": (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+     ,"supply": 0.0
+     ,"precision": 0
+     ,"uri": "default-test-uri"
+     ,"policies": (create-policies DEFAULT) })
+  )
+
+  (expect "create a token with token-id that satisfies t: protocol"
+    true
+    (create-token
+      (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+       0 "default-test-uri" (create-policies DEFAULT)))
+
+  (expect "create-token events"
+     [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [{"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+       {"name": "marmalade-v2.ledger.TOKEN","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 0 0.0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "default-test-uri"]}
+     ]
+     (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "Test enforce-mint")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+     "token-id": "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0"
+    , "account": "k:account"
+    , "account-guard": {"keys": ["account"], "pred": "keys-all"}
+    })
+
+(env-sigs [
+  { 'key: 'mint
+   ,'caps: [(marmalade-v2.ledger.MINT (read-msg "token-id") "k:account" 1.0)
+            (marmalade-v2.guard-policy-v1.MINT (read-string "token-id") "k:account" 1.0)
+   ]
+   }])
+
+   (expect-failure "enforce-mint cannot be called directly"
+     "Capability not acquired"
+     (enforce-mint (get-token-info "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0") (read-string 'account) (read-keyset 'account-guard ) 1.0)
+   )
+
+  (expect "mint a default token through ledger.mint"
+    true
+    (mint (read-string 'token-id )  (read-string 'account ) (read-keyset 'account-guard ) 1.0))
+
+  (expect "mint events"
+    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 1.0]}
+    ]
+   (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "Test enforce-burn")
+;;TODO
+(rollback-tx)
+
+(begin-tx "Test enforce-offer without quote")
+  (env-hash (hash "enforce-offer-0"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-fungible-account": "k:seller-fungible-account"
+    , "seller-fungible-guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
+    })
+
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+  (env-data {
+      "token-id": "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0"
+     ,"seller": "k:account"
+  })
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]
+    }])
+
+  (expect-failure "enforce-offer cannot be called directly"
+    "Capability not acquired"
+    (enforce-offer (get-token-info (read-string "token-id")) (read-string 'seller) 1.0 "void-sale-id")
+  )
+
+  (expect "start offer by running step 0 of sale"
+    (pact-id)
+    (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
+
+(expect "offer events"
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") "k:account" 1.0 1690025195.0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") "k:account" 1.0 1690025195.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" (create-capability-pact-guard (SALE_PRIVATE (pact-id)))]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") "k:account" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-chain-data {"block-time": (time "2023-07-21T11:26:35Z")})
+
+  (env-sigs
+    [ {'key:'buyer
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))
+      ]}
+  ])
+
+  (env-data {
+    "buyer": "k:buyer"
+   ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
+   })
+
+  (expect "Buy succeeds"
+    (pact-id)
+    (continue-pact 1))
+
+  (expect "buy events"
+   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" "k:buyer" 1.0 1690025195.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:buyer" (read-keyset 'buyer-guard)]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+  ;; Test Withdraw
+
+(rollback-tx)
+
+(begin-tx "Create buyer and market fungible account, fund buyer account")
+
+  (env-data {
+    "buyer-guard": {"keys": ["buyer-fungible"], "pred": "keys-all"}
+   ,"market-guard": {"keys": ["market-fungible"], "pred": "keys-all"}
+   })
+
+  (marmalade-v2.abc.create-account "k:buyer-fungible" (read-keyset 'buyer-guard))
+  (marmalade-v2.abc.create-account "k:market-fungible" (read-keyset 'market-guard))
+  (marmalade-v2.abc.fund "k:buyer-fungible" 2.0)
+(commit-tx)
+
+(begin-tx "Test enforce-offer with quote")
+
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-fungible-account": "k:seller-fungible-account"
+    , "seller-fungible-guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
+    })
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+  (env-data {
+      "token-id": "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0"
+     ,"seller": "k:account"
      ,"quote":{
         "spec": {
           "fungible": marmalade-v2.abc
           ,"price": 2.0
           ,"amount": 1.0
           ,"seller-fungible-account": {
-              "account": "k:account"
-             ,"guard": {"keys": ["account"], "pred": "keys-all"}
+              "account": "k:seller-fungible-account"
+             ,"guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
             }
         }
         ,"seller-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -280,58 +311,64 @@
     }
   )
 
-  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-    (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]
     }])
 
-  (expect "start offer by running step 0 of sale"
-    "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"
+  (expect "start offer with quote spec"
+    (pact-id)
     (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
 
-  (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}
-            , "token-id" : (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
-          }
+(expect "offer events"
+    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
+      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
+      {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 1690025195.0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 1690025195.0 (pact-id)]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (create-capability-pact-guard (SALE_PRIVATE (pact-id)))]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+    ]
+    (map (remove "module-hash")  (env-events true))
   )
 
-  (expect "events"
-    (format "{}" [[
-      {"name": "marmalade-v2.quote-manager.QUOTE","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" (read-msg 'token-id)
-        {"amount": 1.0,"fungible": marmalade-v2.abc,"price": 2.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'seller-guard) }}]}
-      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg" (read-msg 'token-id) (read-keyset 'seller-guard) []]}
-      {"name": "marmalade-v2.ledger.OFFER","params": [(read-msg 'token-id) "k:account" 1.0 1690025195.0]}
-      {"name": "marmalade-v2.ledger.SALE","params": [(read-msg 'token-id) "k:account" 1.0 1690025195.0 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-msg 'token-id) "k:account" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 1.0,"previous": 0.0}]}]])
-    (format "{}" [(map (remove "module-hash")  (env-events true))])
-  )
+  (env-chain-data {"block-time": (time "2023-07-21T11:26:35Z")})
+
+  (env-sigs
+    [{'key:'buyer-fungible
+      ,'caps: [
+        (marmalade-v2.abc.TRANSFER "k:buyer-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0)
+      ]}
+    {'key:'buyer
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))
+      ]}
+  ])
 
   (env-data {
-    "buyer_fungible_account": "k:buyer"
-   ,"buyer": "k:buyer"
-   ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
-   ,"market-guard": {"keys": ["market"], "pred": "keys-all"}
-  })
+    "buyer": "k:buyer"
+   ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:buyer-fungible"
+   })
 
-  (marmalade-v2.abc.create-account "k:buyer" (read-keyset 'buyer-guard))
-  (marmalade-v2.abc.fund "k:buyer" 2.0)
-  (marmalade-v2.abc.create-account "k:market" (read-keyset 'market-guard))
-  (env-sigs
-  [{'key:'buyer
-    ,'caps: [
-      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } ) "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
-      (marmalade-v2.abc.TRANSFER "k:buyer" "c:DzKUkpHP-1-4XUGw1R7WLfXoWtoyICfk6hV437b_IEY" 2.0)
-    ]}])
-
-  (env-hash (hash "offer-0"))
   (expect "Buy succeeds"
-    "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"
+    (pact-id)
     (continue-pact 1))
 
-  (env-data {
-    "buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}})
+  (expect "buy events"
+    [ {"name": "marmalade-v2.abc.TRANSFER","params": ["k:buyer-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0]}
+      {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 2.0]}
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" "k:buyer" 1.0 1690025195.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
 
+;;TODO  Test withdraw
 (rollback-tx)
+; ; (begin-tx "load regular policies")
+; ;   (load "./policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact")
+; ;   (load "./policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact")
+; ; (commit-tx)

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -2,8 +2,6 @@
 
 (typecheck "marmalade-v2.policy-manager")
 
-
-
 (begin-tx "upgrade policy and check if stored policy matches with saved concrete policy")
   (env-sigs [
     { 'key: 'marmalade-admin
@@ -136,7 +134,7 @@
      ,"policies": (create-policies DEFAULT) })
   )
 
-  (expect "create a token with token-id that satisfies t: protocol"
+  (expect "create a token"
     true
     (create-token
       (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
@@ -144,7 +142,7 @@
 
   (expect "create-token events"
      [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [{"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
-       {"name": "marmalade-v2.ledger.TOKEN","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 0 0.0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "default-test-uri"]}
+       {"name": "marmalade-v2.ledger.TOKEN","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 0 0.0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "default-test-uri"]}
      ]
      (map (remove "module-hash")  (env-events true))
   )
@@ -158,7 +156,7 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-     "token-id": "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0"
+     "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
     , "account": "k:account"
     , "account-guard": {"keys": ["account"], "pred": "keys-all"}
     })
@@ -172,7 +170,7 @@
 
    (expect-failure "enforce-mint cannot be called directly"
      "Capability not acquired"
-     (enforce-mint (get-token-info "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0") (read-string 'account) (read-keyset 'account-guard ) 1.0)
+     (enforce-mint (get-token-info "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo") (read-string 'account) (read-keyset 'account-guard ) 1.0)
    )
 
   (expect "mint a default token through ledger.mint"
@@ -180,9 +178,9 @@
     (mint (read-string 'token-id )  (read-string 'account ) (read-keyset 'account-guard ) 1.0))
 
   (expect "mint events"
-    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" 1.0]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" (read-keyset 'account-guard)]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 1.0]}
+    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0]}
     ]
    (map (remove "module-hash")  (env-events true))
   )
@@ -193,28 +191,21 @@
 ;;TODO
 (rollback-tx)
 
-(begin-tx "Test enforce-offer without quote")
+(begin-tx "Test enforce-offer, enforce-withdraw(fail), enforce-buy(succeed) without quote")
   (env-hash (hash "enforce-offer-0"))
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
 
   (env-data {
-      "seller-fungible-account": "k:seller-fungible-account"
-    , "seller-fungible-guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
-    })
-
-  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
-
-  (env-data {
-      "token-id": "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0"
+      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
      ,"seller": "k:account"
   })
 
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
     }])
 
   (expect-failure "enforce-offer cannot be called directly"
@@ -224,43 +215,128 @@
 
   (expect "start offer by running step 0 of sale"
     (pact-id)
-    (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
+    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
 
 (expect "offer events"
-    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") "k:account" 1.0 1690025195.0]}
-      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") "k:account" 1.0 1690025195.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" (create-capability-pact-guard (SALE_PRIVATE (pact-id)))]}
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") "k:account" 1.0 0.0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") "k:account" 1.0 0.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" (account-guard (read-string "token-id") "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs")]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") "k:account" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
-  (env-chain-data {"block-time": (time "2023-07-21T11:26:35Z")})
-
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))
+        (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
       ]}
   ])
 
   (env-data {
-    "buyer": "k:buyer"
+    "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+   ,"seller": "k:account"
+   ,"buyer": "k:buyer"
    ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
-   })
+  })
+
+  (expect-failure "enforce-buy cannot be called directly"
+   "Capability not acquired"
+   (enforce-buy (get-token-info (read-string 'token-id )) (read-string 'seller ) (read-string 'buyer ) (read-keyset 'buyer-guard ) 1.0 (pact-id)))
 
   (expect "Buy succeeds"
     (pact-id)
     (continue-pact 1))
 
   (expect "buy events"
-   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" "k:buyer" 1.0 1690025195.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
-     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:buyer" (read-keyset 'buyer-guard)]}
-     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
-     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:buyer" (read-keyset 'buyer-guard)]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
-  ;; Test Withdraw
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW (read-string 'token-id) "k:account" 1.0 0.0 (pact-id))]
+    }])
+
+  (expect-failure "Withdraw fails after buy is completed"
+    "resumePact: pact completed: y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"
+    (continue-pact 0 true))
+
+(rollback-tx)
+
+
+(begin-tx "Test enforce-offer, enforce-withdraw (succeed), enforce-buy (fail) without quote")
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+     ,"seller": "k:account"
+  })
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
+    }])
+
+  (expect "start offer by running step 0 of sale"
+    (pact-id)
+    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+
+(expect "offer events"
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") "k:account" 1.0 0.0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW (read-string 'token-id) "k:account" 1.0 0.0 (pact-id))]
+    }])
+
+  (expect-failure "enforce-withdraw cannot be called directly"
+    "Capability not acquired"
+    (enforce-withdraw (get-token-info (read-string 'token-id )) (read-string 'seller ) 1.0 (pact-id) ))
+
+  (expect "Withdraw succeeds"
+    (pact-id)
+    (continue-pact 0 true))
+
+  (expect "withdraw events"
+   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-sigs
+    [ {'key:'buyer
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+      ]}
+  ])
+
+  (env-data {
+    "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+   ,"seller": "k:account"
+   ,"buyer": "k:buyer"
+   ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
+  })
+
+  (expect-failure "buy fails after offer is withdrawn"
+   "resumePact: pact completed: i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"
+   (continue-pact 1))
 
 (rollback-tx)
 
@@ -274,9 +350,10 @@
   (marmalade-v2.abc.create-account "k:buyer-fungible" (read-keyset 'buyer-guard))
   (marmalade-v2.abc.create-account "k:market-fungible" (read-keyset 'market-guard))
   (marmalade-v2.abc.fund "k:buyer-fungible" 2.0)
+  (marmalade-v2.abc.fund "k:market-fungible" 2.0)
 (commit-tx)
 
-(begin-tx "Test enforce-offer with quote")
+(begin-tx "Test enforce-offer, enforce-withdraw(succeeds), enforce-buy(fails) with quote and without reserved sale")
 
   (env-hash (hash "enforce-offer-1"))
   (use marmalade-v2.ledger)
@@ -290,10 +367,8 @@
 
   (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
 
-  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
-
   (env-data {
-      "token-id": "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0"
+      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
      ,"seller": "k:account"
      ,"quote":{
         "spec": {
@@ -314,26 +389,41 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")))]
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
     }])
 
   (expect "start offer with quote spec"
     (pact-id)
-    (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
+    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
 
-(expect "offer events"
-    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
-      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
-      {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 1690025195.0]}
-      {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 1690025195.0 (pact-id)]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (create-capability-pact-guard (SALE_PRIVATE (pact-id)))]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
-    ]
-    (map (remove "module-hash")  (env-events true))
-  )
+  (expect "offer events"
+      [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
+        {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
+        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0.0]}
+        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0.0 (pact-id)]}
+        {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+      ]
+      (map (remove "module-hash")  (env-events true))
+    )
 
-  (env-chain-data {"block-time": (time "2023-07-21T11:26:35Z")})
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 (pact-id))]
+    }])
+
+  (expect "Withdraw succeeds"
+    (pact-id)
+    (continue-pact 0 true))
+
+    (expect "withdraw events"
+      [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+      (map (remove "module-hash")  (env-events true))
+    )
 
   (env-sigs
     [{'key:'buyer-fungible
@@ -342,7 +432,7 @@
       ]}
     {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))
+        (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
       ]}
   ])
 
@@ -352,6 +442,84 @@
    ,"buyer_fungible_account": "k:buyer-fungible"
    })
 
+  (expect-failure "Buy fails when called after withdraw"
+    "resumePact: pact completed: i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"
+    (continue-pact 1))
+
+(rollback-tx)
+
+(begin-tx "Test enforce-offer, enforce-withdraw(fails), enforce-buy(succeeds) with quote and without reserved sale")
+
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-fungible-account": "k:seller-fungible-account"
+    , "seller-fungible-guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
+    })
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+
+  (env-data {
+      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+     ,"seller": "k:account"
+     ,"quote":{
+        "spec": {
+          "fungible": marmalade-v2.abc
+          ,"price": 2.0
+          ,"amount": 1.0
+          ,"seller-fungible-account": {
+              "account": "k:seller-fungible-account"
+             ,"guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
+            }
+        }
+        ,"seller-guard": {"keys": ["account"], "pred": "keys-all"}
+        ,"quote-guards": []
+      }
+    }
+  )
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
+    }])
+
+  (expect "start offer with quote spec"
+    (pact-id)
+    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+
+  (expect "offer events"
+      [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
+        {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
+        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0.0]}
+        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0.0 (pact-id)]}
+        {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+      ]
+      (map (remove "module-hash")  (env-events true))
+    )
+
+  (env-data {
+    "buyer": "k:buyer"
+   ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:buyer-fungible"
+   })
+
+   (env-sigs
+     [{'key:'buyer-fungible
+       ,'caps: [
+         (marmalade-v2.abc.TRANSFER "k:buyer-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0)
+       ]}
+     {'key:'buyer
+       ,'caps: [
+         (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+       ]}
+   ])
+
   (expect "Buy succeeds"
     (pact-id)
     (continue-pact 1))
@@ -359,16 +527,143 @@
   (expect "buy events"
     [ {"name": "marmalade-v2.abc.TRANSFER","params": ["k:buyer-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 2.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:account" "k:buyer" 1.0 1690025195.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "k:buyer" (read-keyset 'buyer-guard)]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:TskmY_6Uz3M5PuVNd0Ej50cQS7TjvkRdGsGmjHsv6Y0" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
-;;TODO  Test withdraw
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 (pact-id))]
+    }])
+
+  (expect-failure "Withdraw fails after buy has completed"
+    "resumePact: pact completed: i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"
+    (continue-pact 0 true))
+
 (rollback-tx)
-; ; (begin-tx "load regular policies")
-; ;   (load "./policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact")
-; ;   (load "./policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact")
-; ; (commit-tx)
+
+
+(begin-tx "Test enforce-offer, enforce-withdraw, enforce-buy with quote and reserved sale")
+
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-fungible-account": "k:seller-fungible-account"
+    , "seller-fungible-guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
+    })
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+
+  (env-data {
+      "token-id": "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo"
+     ,"seller": "k:account"
+     ,"quote":{
+        "spec": {
+          "fungible": marmalade-v2.abc
+          ,"price": 2.0
+          ,"amount": 1.0
+          ,"seller-fungible-account": {
+              "account": "k:seller-fungible-account"
+             ,"guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
+            }
+        }
+        ,"seller-guard": {"keys": ["account"], "pred": "keys-all"}
+        ,"quote-guards": [{"keys": ["market"], "pred": "keys-all"}]
+      }
+    }
+  )
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
+    }])
+
+  (expect "start offer with quote spec"
+    (pact-id)
+    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+
+(expect "offer events"
+    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
+      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote ))  (at 'quote-guards (read-msg 'quote ))]}
+      {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0.0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0.0 (pact-id)]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+    ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-data {
+    "buyer": "k:buyer"
+   ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
+   })
+
+   (env-sigs
+     [{'key:"market"
+       ,'caps: [(marmalade-v2.quote-manager.UPDATE_QUOTE_PRICE (pact-id))]}
+     {'key:"market-fungible"
+       ,'caps: [(marmalade-v2.abc.DEBIT "k:market-fungible")]}
+   ])
+
+  ;; REVIEW abc CAP
+  (expect "reserve-sale succeeds"
+    true
+    (reserve-sale (pact-id) 1.0 (read-string 'buyer) (read-keyset 'buyer-guard ) "k:market-fungible"))
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" 1.0 0.0 (pact-id))]
+    }])
+
+  (expect-failure "Withdraw fails when a sale is reserved"
+    "Sale is reserved, unable to withdraw"
+    (continue-pact 0 true))
+
+  (env-sigs
+    [ {'key:'buyer
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+      ]}
+  ])
+
+  (env-data {
+    "buyer": "k:buyer1"
+   ,"buyer-guard": {"keys": ['buyer1], "pred": "keys-all"}
+   })
+
+  (expect-failure "Buy fails when buyer is different from reserved buyer"
+    "Reserved buyer must be buyer"
+    (continue-pact 1))
+
+  (env-data {
+    "buyer": "k:buyer"
+   ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
+   })
+
+  (expect "Buy succeeds"
+    (pact-id)
+    (continue-pact 1))
+
+  (expect "buy events"
+    [ {"name": "marmalade-v2.quote-manager.QUOTE_PRICE_UPDATE","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer"]}
+      {"name": "marmalade-v2.abc.TRANSFER","params": ["k:market-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.0]}
+      {"name": "marmalade-v2.policy-manager.SALE_RESERVED","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 1.0]}
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:account" "k:buyer" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:MnoZfQ-vsr_8xmfUwUWfBSPyfT1aJ9L9SzJ7oOoRJVo" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(rollback-tx)


### PR DESCRIPTION
- Adds check for seller guard at `WITHDRAW` when timeout is set to 0.0
- Reads `buyer_fungible_account` only when the sale is not reserved at `policy-manager.enforce-buy`
- Fixes type error in `policy-manager.enforce-withdraw`
- Add improvements in test flow 