### PR TITLE
Clean remains of enforce-crosschain

### DIFF
--- a/pact/concrete-policies/guard-policy/guard-policy.md
+++ b/pact/concrete-policies/guard-policy/guard-policy.md
@@ -10,6 +10,6 @@ The enforce-init function initializes the policy-guards table for a given token 
 
 The enforce-offer and enforce-buy functions enforce rules related to buying and selling tokens, including checking the sale-id against the currently executing pact.
 
-The enforce-transfer and enforce-crosschain functions enforce rules related to transferring tokens, including checking the sender, receiver, and amount of the transfer against the specified guards.
+The enforce-transfer function enforce rules related to transferring tokens, including checking the sender, receiver, and amount of the transfer against the specified guards.
 
 Finally, the code includes a conditional block that creates the policy-guards table if it does not already exist, or returns a message indicating that the upgrade is complete if the table does exist.

--- a/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+++ b/pact/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
@@ -102,16 +102,6 @@
       amount:decimal )
     true
   )
-
-  (defun enforce-crosschain:bool
-    ( token:object{token-info}
-      sender:string
-      guard:guard
-      receiver:string
-      target-chain:string
-      amount:decimal )
-    (enforce false "Transfer prohibited")
-  )
 )
 
 

--- a/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
+++ b/pact/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
@@ -119,16 +119,6 @@
       sale-id:string )
     true
   )
-
-  (defun enforce-crosschain:bool
-    ( token:object{token-info}
-      sender:string
-      guard:guard
-      receiver:string
-      target-chain:string
-      amount:decimal )
-    (enforce false "Transfer prohibited")
-  )
 )
 
 (if (read-msg 'upgrade)

--- a/pact/policies/policies.md
+++ b/pact/policies/policies.md
@@ -40,9 +40,6 @@ This function enforces the policy related to buying tokens offered for sale. It 
 ## enforce-transfer:
 This function enforces the policy related to transferring tokens from one account to another. It takes in the token object, the sender of the tokens, the guard, the receiver of the tokens, and the amount being transferred. You can define your own policies related to transferring tokens by adding custom checks in this function.
 
-## enforce-crosschain:
-This function enforces the policy related to cross-chain transfers of tokens. It takes in the token object, the sender of the tokens, the guard, the receiver of the tokens on the target chain, the target-chain, and the amount being transferred. You can define your own policies related to cross-chain transfers by adding custom checks in this function.
-
 To define your own policies, simply create a new function with the name of the policy you want to implement and add your custom checks. Make sure the function returns a boolean value indicating whether or not the policy is enforced.
 
 Overall, the token-policy-v2 interface provides a powerful tool for defining policies that govern the behavior of tokens written in Pact on the kadena blockchain. By creating custom functions to enforce policies related to minting, burning, offering, buying, transferring, and cross-chain transfers of tokens, you can ensure that your marmalade token operates in a secure and reliable manner.


### PR DESCRIPTION
enforce-crosschain has been removed from the token-policy interface in Marmalade v2. This PR removes any remaining references to this function that were still left. See https://github.com/kadena-io/marmalade/issues/105 for the rationale behind this.