### PR TITLE
Sale `timeout` type decimal to integer

### DIFF
--- a/examples/basic-bidding-sale/basic-bidding-sale.repl
+++ b/examples/basic-bidding-sale/basic-bidding-sale.repl
@@ -79,12 +79,12 @@
   (env-sigs [
     { 'key: 'account-wrong
     ,'caps: [
-    (marmalade-v2.ledger.OFFER (read-msg 'token-id ) "k:account" 1.0 0.0)]
+    (marmalade-v2.ledger.OFFER (read-msg 'token-id ) "k:account" 1.0 0)]
     }])
 
   (expect-failure "offer fails because of keyset failure"
     "Keyset failure (keys-all): [account]"
-    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+    (sale (read-msg 'token-id) "k:account" 1.0 0))
 (rollback-tx)
 
 (begin-tx "Offer for sale succeeds")
@@ -116,12 +116,12 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-    (marmalade-v2.ledger.OFFER (read-msg 'token-id ) "k:account" 1.0 0.0)]
+    (marmalade-v2.ledger.OFFER (read-msg 'token-id ) "k:account" 1.0 0)]
     }])
 
   (expect "Start offer succeeds"
     "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"
-    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+    (sale (read-msg 'token-id) "k:account" 1.0 0))
 
 (commit-tx)
 
@@ -247,7 +247,7 @@
   (env-sigs [
     { 'key: 'any
     ,'caps: [
-        (marmalade-v2.ledger.BUY (read-msg 'token-id) "k:account" "k:bidder"  1.0 0.0 (read-msg 'sale-id))
+        (marmalade-v2.ledger.BUY (read-msg 'token-id) "k:account" "k:bidder"  1.0 0 (read-msg 'sale-id))
       ]
     }
     ])

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -32,18 +32,6 @@
 (commit-tx)
 
 (begin-tx)
-  (module util GOVERNANCE
-    (defcap GOVERNANCE ()
-      false)
-
-    (defun to-timestamp:decimal (input:time)
-      "Computes an Unix timestamp of the input date"
-      (diff-time input (time "1970-01-01T00:00:00Z"))
-    )
-  )
-(commit-tx)
-
-(begin-tx)
 (use marmalade-v2.ledger)
 
 (use marmalade-v2.util-v1)
@@ -118,12 +106,12 @@
 (env-sigs [
   { 'key: 'account
    ,'caps: [
-   (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) )]
+   (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
    }])
 
 (expect-failure "Offer fails when quote uses a different fungible from registered fungible"
   "(enforce (= fungible (at 'fung...: Failure: Tx Failed: Offer is restricted to sale using fungible: marmalade-v2.abc"
-  (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
+  (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
 
 (env-data {
   "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
@@ -176,12 +164,12 @@
 (env-sigs [
   { 'key: 'account
    ,'caps: [
-   (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) )]
+   (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
    }])
 
 (expect "start offer by running step 0 of sale"
   "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"
-  (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
+  (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
 
 (env-data { "recipient-guard": {"keys": ["seller"], "pred": "keys-all"}})
 
@@ -197,7 +185,7 @@
 (env-sigs
  [{'key:'buyer
   ,'caps: [
-    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (util.to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
     (marmalade-v2.abc.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
    ]}])
 

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -251,7 +251,7 @@
   ;;
 
   (defcap SALE:bool
-    (id:string seller:string amount:decimal timeout:decimal sale-id:string)
+    (id:string seller:string amount:decimal timeout:integer sale-id:string)
     @doc "Wrapper cap/event of SALE of token ID by SELLER of AMOUNT until TIMEOUT block height."
     @event
   )
@@ -260,7 +260,7 @@
     ( id:string
       seller:string
       amount:decimal
-      timeout:decimal
+      timeout:integer
     )
     @doc " Offer->buy escrow pact of AMOUNT of token ID by SELLER with TIMEOUT in blocks. \
          \ Step 1 is offer with withdraw rollback after timeout. \

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -489,7 +489,7 @@
   ;;
 
   (defcap SALE:bool
-    (id:string seller:string amount:decimal timeout:decimal sale-id:string)
+    (id:string seller:string amount:decimal timeout:integer sale-id:string)
     @doc "Wrapper cap/event of SALE of token ID by SELLER of AMOUNT until TIMEOUT block height."
     @event
     (enforce (> amount 0.0) "Amount must be positive")
@@ -498,7 +498,7 @@
   )
 
   (defcap OFFER:bool
-    (id:string seller:string amount:decimal timeout:decimal)
+    (id:string seller:string amount:decimal timeout:integer)
     @doc "Managed cap for SELLER offering AMOUNT of token ID until TIMEOUT."
     @managed
     (enforce (sale-active timeout) "SALE: invalid timeout")
@@ -507,15 +507,15 @@
   )
 
   (defcap WITHDRAW:bool
-    (id:string seller:string amount:decimal timeout:decimal sale-id:string)
+    (id:string seller:string amount:decimal timeout:integer sale-id:string)
     @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after timeout."
     @managed
     (compose-capability (SALE_PRIVATE sale-id))
     (enforce-one "WITHDRAW: still active" [
-      (enforce (= 0.0 timeout) "No timeout set")
+      (enforce (= 0 timeout) "No timeout set")
       (enforce (not (sale-active timeout)) "WITHDRAW: still active")
     ])
-    (if (= 0.0 timeout)
+    (if (= 0 timeout)
       ;; check seller guard
       (enforce-guard (at 'guard (details id seller)))
       ;; skip
@@ -526,7 +526,7 @@
   )
 
   (defcap BUY:bool
-    (id:string seller:string buyer:string amount:decimal timeout:decimal sale-id:string)
+    (id:string seller:string buyer:string amount:decimal timeout:integer sale-id:string)
     @doc "Completes sale OFFER to BUYER."
     @managed
     (enforce (sale-active timeout) "BUY: expired")
@@ -541,7 +541,7 @@
     ( id:string
       seller:string
       amount:decimal
-      timeout:decimal
+      timeout:integer
     )
     (step-with-rollback
       ;; Step 0: offer
@@ -643,9 +643,9 @@
       true
   ))
 
-  (defun sale-active:bool (timeout:decimal)
+  (defun sale-active:bool (timeout:integer)
     @doc "Sale is active until TIMEOUT time."
-    (if (= 0.0 timeout)
+    (if (= 0 timeout)
       true
       (< (at 'block-time (chain-data)) (add-time (time "1970-01-01T00:00:00Z") timeout))
     )

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -511,15 +511,9 @@
     @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after timeout."
     @managed
     (compose-capability (SALE_PRIVATE sale-id))
-    (enforce-one "WITHDRAW: still active" [
-      (enforce (= 0 timeout) "No timeout set")
-      (enforce (not (sale-active timeout)) "WITHDRAW: still active")
-    ])
     (if (= 0 timeout)
-      ;; check seller guard
       (enforce-guard (at 'guard (details id seller)))
-      ;; skip
-      true
+      (enforce (not (sale-active timeout)) "WITHDRAW: still active")
     )
     (compose-capability (DEBIT id (sale-account)))
     (compose-capability (CREDIT id seller))

--- a/pact/ledger/ledger.repl
+++ b/pact/ledger/ledger.repl
@@ -153,8 +153,8 @@
   )
 
   (expect "offer events"
-    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 1690025195.0]}
-      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 1690025195.0 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 1690025195]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string "account") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string "account"),"current": 0.0,"previous": 1.0} {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 1.0,"previous": 0.0}]}]
@@ -198,7 +198,7 @@
   )
 
   (expect "withdraw events"
-    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "k:account" 1.0 1690025195.0 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "k:account" 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" "k:account" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" 1.0 {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
@@ -214,12 +214,12 @@
 
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 0.0)]}
+   ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 0)]}
 ])
 
 (expect "offer succeeds"
   (pact-id)
-  (sale (read-string "token-id") (read-string "account") 1.0 0.0)
+  (sale (read-string "token-id") (read-string "account") 1.0 0)
 )
 
 (expect "Seller account is debited"
@@ -233,8 +233,8 @@
 )
 
 (expect "offer events"
-  [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 0.0]}
-    {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 0.0 (pact-id)]}
+  [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 0]}
+    {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 0 (pact-id)]}
     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" (create-capability-pact-guard (SALE_PRIVATE (pact-id)))]}
     {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string "account") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" 1.0]}
     {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string "account"),"current": 0.0,"previous": 1.0} {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 1.0,"previous": 0.0}]}]
@@ -255,7 +255,7 @@
 
 (env-sigs [
   { 'key: 'any
-   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0.0 (pact-id))]}
+   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0 (pact-id))]}
 ])
 
 (expect-failure "withdraw fails when sig is not signed"
@@ -265,7 +265,7 @@
 
 (env-sigs [
   { 'key: 'account
-   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0.0 (pact-id))]}
+   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0 (pact-id))]}
 ])
 
 (expect "withdraw succeeds"
@@ -275,7 +275,7 @@
 
 (expect "withdraw events"
   [
-    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "k:account" 1.0 0.0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
+    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "k:account" 1.0 0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" "k:account" 1.0]}
     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:YxyMWZItsZ_bxQgq7PzzR8RaD_xDxi1zlIOqGRoler4" 1.0 {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}
   ]}]

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -67,9 +67,9 @@
      ,'guard-policy: (contains (get-concrete-policy GUARD_POLICY) policies)
     }
   )
-  
-  (defun to-timestamp:decimal (input:time)
+
+  (defun to-timestamp:integer (input:time)
     "Computes an Unix timestamp of the input date"
-    (diff-time input (time "1970-01-01T00:00:00Z"))
+    (floor (diff-time input (time "1970-01-01T00:00:00Z")))
   )
 )

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -215,7 +215,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0)]
     }])
 
   (expect-failure "enforce-offer cannot be called directly"
@@ -225,11 +225,11 @@
 
   (expect "start offer by running step 0 of sale"
     (pact-id)
-    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+    (sale (read-msg 'token-id) "k:account" 1.0 0))
 
 (expect "offer events"
-    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") "k:account" 1.0 0.0]}
-      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") "k:account" 1.0 0.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") "k:account" 1.0 0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") "k:account" 1.0 0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" (account-guard (read-string "token-id") "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs")]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") "k:account" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 1.0,"previous": 0.0}]}]
@@ -239,7 +239,7 @@
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0 (pact-id))
       ]}
   ])
 
@@ -259,7 +259,7 @@
     (continue-pact 1))
 
   (expect "buy events"
-   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:buyer" (read-keyset 'buyer-guard)]}
      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
@@ -269,7 +269,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW (read-string 'token-id) "k:account" 1.0 0.0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW (read-string 'token-id) "k:account" 1.0 0 (pact-id))]
     }])
 
   (expect-failure "Withdraw fails after buy is completed"
@@ -294,16 +294,16 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0)]
     }])
 
   (expect "start offer by running step 0 of sale"
     (pact-id)
-    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+    (sale (read-msg 'token-id) "k:account" 1.0 0))
 
 (expect "offer events"
-    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") "k:account" 1.0 0.0]}
-      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") "k:account" 1.0 0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") "k:account" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}]
@@ -313,7 +313,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW (read-string 'token-id) "k:account" 1.0 0.0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW (read-string 'token-id) "k:account" 1.0 0 (pact-id))]
     }])
 
   (expect-failure "enforce-withdraw cannot be called directly"
@@ -325,7 +325,7 @@
     (continue-pact 0 true))
 
   (expect "withdraw events"
-   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
@@ -338,7 +338,7 @@
       ]}
     {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0 (pact-id))
       ]}
   ])
 
@@ -403,18 +403,18 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0)]
     }])
 
   (expect "start offer with quote spec"
     (pact-id)
-    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+    (sale (read-msg 'token-id) "k:account" 1.0 0))
 
   (expect "offer events"
       [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
         {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
-        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0.0]}
-        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0.0 (pact-id)]}
+        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0]}
+        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0 (pact-id)]}
         {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
         {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
         {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
@@ -425,7 +425,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0 (pact-id))]
     }])
 
   (expect "Withdraw succeeds"
@@ -433,7 +433,7 @@
     (continue-pact 0 true))
 
     (expect "withdraw events"
-      [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
         {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
         {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
       (map (remove "module-hash")  (env-events true))
@@ -446,7 +446,7 @@
       ]}
     {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0 (pact-id))
       ]}
   ])
 
@@ -498,18 +498,18 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0)]
     }])
 
   (expect "start offer with quote spec"
     (pact-id)
-    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+    (sale (read-msg 'token-id) "k:account" 1.0 0))
 
   (expect "offer events"
       [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
         {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
-        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0.0]}
-        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0.0 (pact-id)]}
+        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0]}
+        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0 (pact-id)]}
         {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
         {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
         {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
@@ -530,7 +530,7 @@
        ]}
      {'key:'buyer
        ,'caps: [
-         (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+         (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0 (pact-id))
        ]}
    ])
 
@@ -541,7 +541,7 @@
   (expect "buy events"
     [ {"name": "marmalade-v2.abc.TRANSFER","params": ["k:buyer-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 2.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
@@ -551,7 +551,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0 (pact-id))]
     }])
 
   (expect-failure "Withdraw fails after buy has completed"
@@ -597,18 +597,18 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0.0)]
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 0)]
     }])
 
   (expect "start offer with quote spec"
     (pact-id)
-    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+    (sale (read-msg 'token-id) "k:account" 1.0 0))
 
 (expect "offer events"
     [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
       {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote ))  (at 'quote-guards (read-msg 'quote ))]}
-      {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0.0]}
-      {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0.0 (pact-id)]}
+      {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0 (pact-id)]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
@@ -636,7 +636,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0.0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" 1.0 0 (pact-id))]
     }])
 
   (expect-failure "Withdraw fails when a sale is reserved"
@@ -646,7 +646,7 @@
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0 (pact-id))
       ]}
   ])
 
@@ -673,7 +673,7 @@
       {"name": "marmalade-v2.abc.TRANSFER","params": ["k:market-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.0]}
       {"name": "marmalade-v2.policy-manager.SALE_RESERVED","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 1.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:44-d3yyIgC8RRe4Bzc3A9Wvcz2PdB89aHyx_rT3156U" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -96,12 +96,12 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" 1.0 0.0)
+      (marmalade-v2.ledger.OFFER "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" 1.0 0)
      ]}])
 
   (expect "Offer token for sale"
     "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"
-    (sale (read-msg 'token-id) "k:account" 1.0 0.0))
+    (sale (read-msg 'token-id) "k:account" 1.0 0))
 
   (env-data {
     "account-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -112,8 +112,8 @@
   (expect "Offer with quote events"
     [ {"name": "marmalade-v2.quote-manager.QUOTE","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" {"amount": 1.0,"fungible": marmalade-v2.abc,"price": 10.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'account-guard )}}]}
       {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" (read-keyset 'account-guard) [(read-keyset 'market-guard)]]}
-      {"name": "marmalade-v2.ledger.OFFER","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" 1.0 0.0]}
-      {"name": "marmalade-v2.ledger.SALE","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" 1.0 0.0 "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"]}
+      {"name": "marmalade-v2.ledger.OFFER","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" 1.0 0]}
+      {"name": "marmalade-v2.ledger.SALE","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" 1.0 0 "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo" (account-guard (read-string "token-id") "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo")]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo","current": 1.0,"previous": 0.0}]}]
@@ -233,7 +233,7 @@
   (env-sigs [
      { 'key: 'any
      ,'caps: [
-         (marmalade-v2.ledger.BUY "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" "k:buyer"  1.0 0.0 (read-string 'sale-id))
+         (marmalade-v2.ledger.BUY "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" "k:buyer"  1.0 0 (read-string 'sale-id))
        ]
      }
    ])


### PR DESCRIPTION
- changes `timeout` argument type to integer from decimal. 

The integer type represents "unix timestamp" in v2, instead of "block numbers" in v1, an API upgrade for user convenience. 
Users can input `time` with the function, `util-v1.to-timestamp`, which takes in `time` type and converts into unix timestamp in integer. 

Closes #131 