### PR TITLE
Update poly-fungible-v3 + Change the tokenId and token creation process to prevent frontrunning 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Creation steps:
 
 - Generate a unique `token-id` by calling `(ledger.create-token-id details creation-guard)`
 - Create the token by calling `(ledger.create-token ... creation-guard)`
-   * This transaction must be signed with the keyset `creation-guard` (unrestricted signature)
+   * This transaction must include the `TOKEN` capability signed with the keyset `creation-guard`
 
 
 ### Mint Token

--- a/README.md
+++ b/README.md
@@ -52,8 +52,26 @@ A Token is created in marmalade via running `create-token`. Arguments include:
 - `precision`: Number of decimals allowed for for the token amount. For one-off token, precision must be 0, and should be enforced in the policy's `enforce-init`.
 - `uri`: url to external JSON containing metadata
 - `policies`: policies contract with custom functions to execute at marmalade functions
+- `creation-guard`: Non stored guard (usally a Keyset). Must be used to reserve a `token-id`
 
 `policy-manager.enforce-init` calls `policy:enforce-init` in stored token-policies, and the function is executed in `ledger.create-token`.
+
+#### Creation guard usage
+
+Before creating a token, the creator must choose a temporary guard, which can be
+
+- An usual keyset. (eg: one already used in the guard-policy).
+- But also a single-use keyset, since it isn't stored and won't be needed anymore.
+- Some more complex setups could involve other guard types (eg: when token creations are managed by a SC).
+
+This guard will be part of the `token-id` (starting `t:`) creation. As a consequence, it protects the legit creator from being front-runned during token creation. With this mechanism, only the legit creator who owns the creation key can create a specific `token-id`.
+
+Creation steps:
+
+- Generate a unique `token-id` by calling `(ledger.create-token-id details creation-guard)`
+- Create the token by calling `(ledger.create-token ... creation-guard)`
+   * This transaction must be signed with the keyset `creation-guard` (unrestricted signature)
+
 
 ### Mint Token
 

--- a/examples/basic-bidding-sale/basic-bidding-sale.repl
+++ b/examples/basic-bidding-sale/basic-bidding-sale.repl
@@ -1,6 +1,14 @@
 ;;load policy manager, ledger
 (load "../../pact/policy-manager/policy-manager.repl")
 
+(begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
 (begin-tx "Load contract and dependencies")
   (env-sigs [
     { 'key: 'basic-sale-admin
@@ -18,13 +26,13 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } g-utils.ALWAYS-TRUE)
     ,"account": "k:account"
   })
 
   (expect "create a default token without any policies"
     true
-    (create-token (read-msg 'token-id) 0 "test-uri" [] ))
+    (create-token (read-msg 'token-id) 0 "test-uri" [] g-utils.ALWAYS-TRUE))
 
   (env-sigs [
     { 'key: 'random
@@ -32,7 +40,7 @@
     }])
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   })
@@ -59,7 +67,7 @@
   })
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } g-utils.ALWAYS-TRUE)
     ,"quote": {
       "spec": {
         "seller-fungible-account": {
@@ -97,7 +105,7 @@
   })
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } g-utils.ALWAYS-TRUE)
     ,"quote": {
       "spec": {
         "seller-fungible-account": {
@@ -132,7 +140,7 @@
   (use free.basic-bidding-sale)
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } )
+    "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } g-utils.ALWAYS-TRUE)
     ,"sale-id": "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"
     ,"bidder-guard": {"keys": ["bidder"], "pred": "keys-all"}
   })

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -13,12 +13,20 @@
   (marmalade-v2.abc.create-account "k:creator" (read-keyset 'creator-guard))
 (commit-tx)
 
+(begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
 (begin-tx "Creating collection")
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
+    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY)} g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -47,7 +55,7 @@
 
  (expect-failure "create token fails if operator guard isn't present"
    "Keyset failure"
-   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx "Create token")
@@ -62,7 +70,7 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 
 (commit-tx)
 
@@ -104,8 +112,8 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
-  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE )
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -129,11 +137,11 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 
   (expect-failure "creating another token will exceed collection-size"
     "Exceeds collection size"
-    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx "Create collection with unlimited size and add two tokens")
@@ -142,8 +150,8 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
-  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } )
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -167,9 +175,9 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 
   (expect "create another token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ))
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
 (rollback-tx)

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -13,17 +13,11 @@
   (marmalade-v2.abc.create-account "k:creator" (read-keyset 'creator-guard))
 (commit-tx)
 
-(begin-tx)
-(module g-utils G
-  (defcap G() true)
-  (defun always-true:bool () true)
-  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
-)
-(commit-tx)
 (begin-tx "Creating collection fails without operator guard")
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
   (env-data {
     "ks": {"keys": ["operator"], "pred": "keys-all"}
   })
@@ -37,8 +31,9 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY)} g-utils.ALWAYS-TRUE)
+    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY)} ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -69,18 +64,20 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
 
   (env-sigs [])
 
  (expect-failure "create token fails if operator guard isn't present"
    "Keyset failure"
-   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
+   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx "Create token")
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
 
   (env-sigs [
     { 'key: 'operator
@@ -89,7 +86,7 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
+    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
 
 (commit-tx)
 
@@ -129,10 +126,11 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
 
   (env-data {
-    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE )
-  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } ALWAYS-TRUE )
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -161,21 +159,22 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
 
   (expect-failure "creating another token will exceed collection-size"
     "Exceeds collection size"
-    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx "Create collection with unlimited size and add two tokens")
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
 
   (env-data {
-    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
-  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } g-utils.ALWAYS-TRUE)
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } ALWAYS-TRUE)
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
@@ -204,9 +203,9 @@
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
 
   (expect "create another token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
-    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) g-utils.ALWAYS-TRUE))
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
 (rollback-tx)

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -6,11 +6,19 @@
 (use marmalade-v2.policy-manager [NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 (commit-tx)
 
+(begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
 (begin-tx "Create token without mint guard")
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
 })
@@ -22,7 +30,7 @@
 
 (expect "create token succeeds without mint-guard"
  true
- (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ))
+ (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) g-utils.ALWAYS-TRUE))
 
 (expect "Mint token succeeds without mint-guard"
   true
@@ -35,7 +43,7 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } g-utils.ALWAYS-TRUE)
   ,"account": "k:account"
   ,"mint_guard": {"keys": ["mint"], "pred": "keys-all"}
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -43,7 +51,7 @@
 
 (expect "create token succeeds with mint-guard"
  true
- (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ))
+ (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) g-utils.ALWAYS-TRUE))
 
  (env-sigs [
    { 'key: 'mint-false

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -6,19 +6,12 @@
 (use marmalade-v2.policy-manager [NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
 (commit-tx)
 
-(begin-tx)
-(module g-utils G
-  (defcap G() true)
-  (defun always-true:bool () true)
-  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
-)
-(commit-tx)
-
 (begin-tx "Create token without mint guard")
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } g-utils.ALWAYS-TRUE)
+   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } ALWAYS-TRUE)
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
 })
@@ -30,7 +23,7 @@
 
 (expect "create token succeeds without mint-guard"
  true
- (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) g-utils.ALWAYS-TRUE))
+ (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ALWAYS-TRUE))
 
 (expect "Mint token succeeds without mint-guard"
   true
@@ -42,8 +35,9 @@
 (begin-tx "Create token without operator guard fails")
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
 (env-data {
-   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } g-utils.ALWAYS-TRUE)
+   "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } ALWAYS-TRUE)
   ,"account": "k:account"
   ,"mint_guard": {"keys": ["mint"], "pred": "keys-all"}
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -51,7 +45,7 @@
 
 (expect "create token succeeds with mint-guard"
  true
- (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) g-utils.ALWAYS-TRUE))
+ (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ALWAYS-TRUE))
 
  (env-sigs [
    { 'key: 'mint-false

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -3,6 +3,14 @@
 (typecheck "marmalade-v2.non-fungible-policy-v1")
 
 (begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
+(begin-tx)
   (use marmalade-v2.policy-manager [ NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
   (use marmalade-v2.util-v1 [concrete-policy-bool])
 
@@ -32,7 +40,7 @@
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } )
+    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } g-utils.ALWAYS-TRUE)
     ,"account": "k:account"
     ,"nfp-mint-guard": {"keys": ["account"], "pred": "keys-all"}
     ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -43,7 +51,7 @@
 (begin-tx "Create a non-fungible token")
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
-  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) )
+  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) g-utils.ALWAYS-TRUE)
 (commit-tx)
 
 (begin-tx "Mint with a supply other then 1 fails ")

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -3,16 +3,9 @@
 (typecheck "marmalade-v2.non-fungible-policy-v1")
 
 (begin-tx)
-(module g-utils G
-  (defcap G() true)
-  (defun always-true:bool () true)
-  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
-)
-(commit-tx)
-
-(begin-tx)
   (use marmalade-v2.policy-manager [ NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
   (use marmalade-v2.util-v1 [concrete-policy-bool])
+  (use mini-guard-utils)
 
   (module util GOV
     (defcap GOV () true)
@@ -30,6 +23,7 @@
 (begin-tx)
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
   (env-data {
     "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
   })
@@ -39,23 +33,25 @@
 (begin-tx "Create a non-fungible token fails when precision is not 0")
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
 
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 1, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } g-utils.ALWAYS-TRUE)
+    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 1, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } ALWAYS-TRUE)
     ,"account": "k:account"
     ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
   })
 
 (expect-failure  "Precision should be 0"
-  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) g-utils.ALWAYS-TRUE))
+  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) ALWAYS-TRUE))
 (rollback-tx)
 
 
 (begin-tx)
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
   (env-data {
-    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } g-utils.ALWAYS-TRUE)
+    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } ALWAYS-TRUE)
     ,"account": "k:account"
     ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
   })
@@ -65,7 +61,8 @@
 (begin-tx "Create a non-fungible token")
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
-  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) g-utils.ALWAYS-TRUE)
+  (use mini-guard-utils)
+  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) ALWAYS-TRUE)
 (commit-tx)
 
 

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -3,14 +3,6 @@
 (typecheck "marmalade-v2.royalty-policy-v1")
 
 (begin-tx)
-(module g-utils G
-  (defcap G() true)
-  (defun always-true:bool () true)
-  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
-)
-(commit-tx)
-
-(begin-tx)
 (use marmalade-v2.policy-manager [concrete-policy concrete-policy])
 (use marmalade-v2.ledger)
 
@@ -26,9 +18,10 @@
 (begin-tx)
 (use marmalade-v2.ledger)
 (use marmalade-v2.util-v1)
+(use mini-guard-utils)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
  ,"account": "account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -47,19 +40,21 @@
 (use marmalade-v2.ledger)
 
 (use marmalade-v2.util-v1)
+(use mini-guard-utils)
 
 (expect-failure "create-token with negative royalty rate fails"
   "Invalid royalty rate"
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx)
 (use marmalade-v2.ledger)
 
 (use marmalade-v2.util-v1)
+(use mini-guard-utils)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -72,7 +67,7 @@
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
 
 (env-sigs [
   { 'key: 'account
@@ -88,9 +83,10 @@
 (use marmalade-v2.ledger)
 
 (use marmalade-v2.util-v1)
+(use mini-guard-utils)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -103,11 +99,11 @@
 
 (expect-failure "Creator guard does not match creator"
   "Creator guard does not match"
-  (create-token (read-msg 'token-id) 0 "test2-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
+  (create-token (read-msg 'token-id) 0 "test2-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
 
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -120,16 +116,17 @@
 
 (expect-failure "Account does not exist on fungible"
   "row not found: k:creator"
-  (create-token (read-msg 'token-id) 0 "test2-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
+  (create-token (read-msg 'token-id) 0 "test2-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
 
 (commit-tx)
 
 (begin-tx "Royalty rates")
 (use marmalade-v2.ledger)
 (use marmalade-v2.util-v1)
+(use mini-guard-utils)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test3-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test3-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -143,10 +140,10 @@
 
 (expect-failure "Royalty rate should be decimal"
   "expected decimal, found integer"
-  (create-token (read-msg 'token-id) 0 "test3-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
+  (create-token (read-msg 'token-id) 0 "test3-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test3-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test3-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -159,7 +156,7 @@
 
 (expect-failure "Royalty rate be between 0.0 and 1.0"
   "Invalid royalty rate"
-  (create-token (read-msg 'token-id) 0 "test3-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
+  (create-token (read-msg 'token-id) 0 "test3-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
 
 
 (commit-tx)
@@ -169,6 +166,7 @@
 (env-hash (hash "offer-royalty-0"))
 (use marmalade-v2.ledger)
 (use marmalade-v2.util-v1)
+(use mini-guard-utils)
 
 (env-data {
   "seller-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -178,7 +176,7 @@
 (marmalade-v2.def.create-account "k:account" (read-keyset 'seller-guard))
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
   ,"quote":{
      "spec": {
        "fungible": marmalade-v2.def
@@ -206,7 +204,7 @@
   (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
   ,"quote":{
      "spec": {
        "fungible": marmalade-v2.abc
@@ -228,6 +226,7 @@
 (env-hash (hash "offer-royalty-0"))
 (use marmalade-v2.ledger)
 (use marmalade-v2.util-v1)
+(use mini-guard-utils)
 
 (env-data {
   "seller-guard": {"keys": ["account"], "pred": "keys-all"}
@@ -236,7 +235,7 @@
 (marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
   ,"quote":{
      "spec": {
        "fungible": marmalade-v2.abc
@@ -277,7 +276,7 @@
 (env-sigs
  [{'key:'buyer
   ,'caps: [
-    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE) "k:account" "k:buyer"  1.0 (to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) "k:account" "k:buyer"  1.0 (to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
     (marmalade-v2.abc.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
    ]}])
 

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -3,6 +3,14 @@
 (typecheck "marmalade-v2.royalty-policy-v1")
 
 (begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
+(begin-tx)
 (use marmalade-v2.policy-manager [concrete-policy concrete-policy])
 (use marmalade-v2.ledger)
 
@@ -16,7 +24,7 @@
 (use marmalade-v2.util-v1)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} g-utils.ALWAYS-TRUE)
  ,"account": "account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -50,7 +58,7 @@
 
 (expect-failure "create-token with negative royalty rate fails"
   "Invalid royalty rate"
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
 (rollback-tx)
 
 (begin-tx)
@@ -59,7 +67,7 @@
 (use marmalade-v2.util-v1)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
@@ -72,7 +80,7 @@
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) g-utils.ALWAYS-TRUE))
 
 (env-sigs [
   { 'key: 'account
@@ -97,7 +105,7 @@
 (marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE)
 
   ,"quote":{
      "spec": {
@@ -139,7 +147,7 @@
 (env-sigs
  [{'key:'buyer
   ,'caps: [
-    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (util.to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+    (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } g-utils.ALWAYS-TRUE) "k:account" "k:buyer"  1.0 (util.to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
     (marmalade-v2.abc.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
    ]}])
 

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -39,7 +39,7 @@
 
 (expect-failure "create-token with royalty_spec with fungible other than coin fails"
   "Royalty support is restricted to coin"
-  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ))
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
 
 (rollback-tx)
 
@@ -49,7 +49,7 @@
 (use mini-guard-utils)
 
 (env-data {
-  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} )
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
  ,"account": "account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {

--- a/pact/kip/poly-fungible-v3.pact
+++ b/pact/kip/poly-fungible-v3.pact
@@ -69,11 +69,6 @@
     @event
   )
 
-  (defcap TOKEN:bool (id:string precision:integer supply:decimal policies:[module{kip.token-policy-v2}] uri:string)
-    @doc " Emitted when token ID is created."
-    @event
-  )
-
   (defcap ACCOUNT_GUARD:bool (id:string account:string guard:guard)
     @doc " Emitted when ACCOUNT guard is updated."
     @event
@@ -130,20 +125,6 @@
       [ (property (!= id ""))
         (property (!= account ""))
         (property (>= amount 0.0))
-      ]
-  )
-
-  (defun create-token:bool
-    ( id:string
-      precision:integer
-      uri:string
-      policies:[module{kip.token-policy-v2}]
-    )
-    @doc "Create a new token with ID, PRECISION, URI, and POLICY."
-    @model
-      [ (property (!= id ""))
-        (property (>= precision 0))
-        (property (!= uri ""))
       ]
   )
 

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -86,7 +86,7 @@
     @event true
   )
 
-  (defcap TOKEN:bool (id:string precision:integer supply:decimal policies:[module{kip.token-policy-v2}] uri:string)
+  (defcap TOKEN:bool (id:string precision:integer policies:[module{kip.token-policy-v2}] uri:string)
     @event
     true
   )
@@ -244,7 +244,7 @@
       "supply": 0.0,
       "policies": policies
     })
-    (emit-event (TOKEN id precision 0.0 policies uri))
+    (emit-event (TOKEN id precision policies uri))
   )
 
   (defun check-reserved:string (token-id:string)

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -231,13 +231,12 @@
     (let ((token-details { 'uri: uri, 'precision: precision, 'policies: (sort policies) }))
       (enforce-token-reserved id token-details creation-guard)
     )
+    (with-capability (INIT-CALL id precision uri)
+      ;; maps policy list and calls policy::enforce-init
+      (marmalade-v2.policy-manager.enforce-init
+        { 'id: id, 'supply: 0.0, 'precision: precision, 'uri: uri,  'policies: policies})
+    )
     (with-capability (TOKEN id precision policies uri creation-guard)
-      (with-capability (INIT-CALL id precision uri)
-        ;; maps policy list and calls policy::enforce-init
-        (marmalade-v2.policy-manager.enforce-init
-          { 'id: id, 'supply: 0.0, 'precision: precision, 'uri: uri,  'policies: policies})
-      )
-
       (insert tokens id {
         "id": id,
         "uri": uri,

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -216,7 +216,7 @@
   (defun create-token-id:string (token-details:object{token-details}
                                  creation-guard:guard)
     (format "t:{}"
-      [(hash (+ {'cg:creation-guard} token-details))])
+      [(hash [token-details (at 'chain-id (chain-data)) creation-guard])])
   )
 
   (defun create-token:bool

--- a/pact/ledger/ledger.repl
+++ b/pact/ledger/ledger.repl
@@ -46,7 +46,7 @@
 
   (expect "create-token events"
      (format "{}" [[
-     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" 0 0.0 [] "test-uri"]}]])
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" 0 [] "test-uri"]}]])
      (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 

--- a/pact/ledger/ledger.repl
+++ b/pact/ledger/ledger.repl
@@ -46,7 +46,7 @@
 
   (expect "create-token events"
      (format "{}" [[
-     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" 0 [] "test-uri"]}]])
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" 0 [] "test-uri" ALWAYS-TRUE]}]])
      (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 

--- a/pact/ledger/ledger.repl
+++ b/pact/ledger/ledger.repl
@@ -35,18 +35,18 @@
        0 "test-uri" [] ALWAYS-TRUE))
 
   (expect "Token info is inserted into table"
-    { "id": "t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0"
+    { "id": "t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q"
      ,"supply": 0.0
      ,"precision": 0
      ,"uri": "test-uri"
      ,"policies": []
     }
-    (get-token-info "t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0")
+    (get-token-info "t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q")
   )
 
   (expect "create-token events"
      (format "{}" [[
-     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0" 0 0.0 [] "test-uri"]}]])
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" 0 0.0 [] "test-uri"]}]])
      (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 
@@ -56,7 +56,7 @@
   (use marmalade-v2.ledger)
 
   (env-data {
-     "token-id": "t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0"
+     "token-id": "t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q"
     ,"account": "k:account"
     ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
     })
@@ -108,7 +108,7 @@
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
 
   (env-data {
-     "token-id": "t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0"
+     "token-id": "t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q"
     ,"account": "k:account"
     ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
     })
@@ -199,9 +199,9 @@
   )
 
   (expect "withdraw events"
-    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0" "k:account" 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" "k:account" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0" 1.0 {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" "k:account" 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" 1.0 {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
@@ -276,9 +276,9 @@
 
 (expect "withdraw events"
   [
-    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0" "k:account" 1.0 0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
-    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0" "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" "k:account" 1.0]}
-    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:QmIAZkXhVwATG3YOfigFOh6oN1Vtbyk4BYUQJcDZmb0" 1.0 {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}
+    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" "k:account" 1.0 0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" "k:account" 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:YfGfxTbXgxIHcHgGLoEb9UMHjTT-jYeKwnxh_DPoV2Q" 1.0 {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}
   ]}]
   (map (remove "module-hash")  (env-events true))
 )

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -136,7 +136,7 @@
 
   (expect "create-token events"
      (format "{}" [[
-     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" 0 0.0 [] "test-uri"]}]])
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" 0 [] "test-uri"]}]])
      (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -136,7 +136,7 @@
 
   (expect "create-token events"
      (format "{}" [[
-     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" 0 [] "test-uri"]}]])
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" 0 [] "test-uri" (read-keyset 'c-ks)]}]])
      (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -125,18 +125,18 @@
        0 "test-uri" [] (read-keyset 'c-ks)))
 
   (expect "Token info is inserted into table"
-    { "id": "t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM"
+    { "id": "t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo"
      ,"supply": 0.0
      ,"precision": 0
      ,"uri": "test-uri"
      ,"policies": []
     }
-    (get-token-info "t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM")
+    (get-token-info "t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo")
   )
 
   (expect "create-token events"
      (format "{}" [[
-     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM" 0 0.0 [] "test-uri"]}]])
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" 0 0.0 [] "test-uri"]}]])
      (format "{}" [(map (remove "module-hash")  (env-events true))])
   )
 
@@ -146,7 +146,7 @@
   (use marmalade-v2.ledger)
 
   (env-data {
-     "token-id": "t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM"
+     "token-id": "t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo"
     ,"account": "k:account"
     ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
     })
@@ -198,7 +198,7 @@
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
 
   (env-data {
-     "token-id": "t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM"
+     "token-id": "t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo"
     ,"account": "k:account"
     ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
     })
@@ -289,9 +289,9 @@
   )
 
   (expect "withdraw events"
-    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM" "k:account" 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" "k:account" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM" 1.0 {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" "k:account" 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" 1.0 {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
@@ -366,9 +366,9 @@
 
 (expect "withdraw events"
   [
-    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM" "k:account" 1.0 0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
-    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM" "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" "k:account" 1.0]}
-    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:VfzwLkHHb_MVY1vzGW5WgyIcKHf9y-ijkhNkM2FUzQM" 1.0 {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}
+    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" "k:account" 1.0 0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" "k:account" 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:kLIufgbtfmnZoX5o_U02wFfmXkDU1EtqZJLVTesALWo" 1.0 {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}
   ]}]
   (map (remove "module-hash")  (env-events true))
 )

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -138,7 +138,7 @@
        0 "default-test-uri" [] ALWAYS-TRUE))
 
   (expect "create-token events"
-     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 0 [] "default-test-uri"]}]
+     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 0 [] "default-test-uri" ALWAYS-TRUE]}]
      (map (remove "module-hash")  (env-events true))
   )
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -65,7 +65,7 @@
   (load "../test/abc.pact")
 (commit-tx)
 
-(typecheck "marmalade-v2.policy-manager")
+;(typecheck "marmalade-v2.policy-manager")
 
 (begin-tx "load concrete-polices")
   (load "../concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact")
@@ -88,10 +88,13 @@
 (use marmalade-v2.policy-manager)
 (use marmalade-v2.util-v1)
 
+(env-data { 'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}})
 (env-data {
-  "default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
- ,"reserved-token-id": (create-token-id { 'uri: "marmalade:uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
- ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-policies EMPTY) } )
+  'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}
+ ,'bad-c-ks: {"keys": ["bad-creation-guard"], "pred": "keys-all"}
+ ,"default-token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT)} (read-keyset 'c-ks))
+ ,"reserved-token-id": (create-token-id { 'uri: "marmalade:uri", 'precision: 0, 'policies: (create-policies DEFAULT)} (read-keyset 'c-ks))
+ ,"empty-token-id": (create-token-id { 'uri: "test-uri-1", 'precision: 0, 'policies: (create-policies EMPTY)} (read-keyset 'c-ks))
  ,"wrong-token-protocol-id": "t:wrong"
  ,"wrong-token-id": "wrong"
  ,"account": "k:account"
@@ -103,28 +106,34 @@
    ,'caps: [(marmalade-v2.ledger.MINT (read-msg "default-token-id") "k:account" 1.0)
             (marmalade-v2.guard-policy-v1.MINT (read-msg "default-token-id") "k:account" 1.0)
             (marmalade-v2.ledger.MINT (read-msg 'empty-token-id) "k:account" 1.0)
-   ]
-   }])
+   ]},
+  { 'key: "creation-guard"
+   ,'caps: []}
+  ])
+
+(expect-failure "create a token without signing with the right creation guard"
+  "Keyset failure"
+  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-policies DEFAULT) (read-keyset 'bad-c-ks) ))
 
 (expect-failure "create a token with uri starting with marmalade fails"
   "Reserved protocol: marmalade:"
-  (create-token (read-msg 'reserved-token-id) 0 "marmalade:uri" (create-policies DEFAULT) ))
+  (create-token (read-msg 'reserved-token-id) 0 "marmalade:uri" (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
 (expect-failure "create a token with unmatching token-id"
   "Token protocol violation"
-  (create-token (read-msg 'wrong-token-protocol-id) 0 "test-uri" (create-policies DEFAULT) ))
+  (create-token (read-msg 'wrong-token-protocol-id) 0 "test-uri" (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
 (expect-failure "create a token without token protocol"
   "Unrecognized reserved protocol"
-  (create-token (read-msg 'wrong-token-id) 0 "test-uri" (create-policies DEFAULT) ))
+  (create-token (read-msg 'wrong-token-id) 0 "test-uri" (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
 (expect "create a default token with quote-policy, non-fungible-policy"
   true
-  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-policies DEFAULT) ))
+  (create-token (read-msg 'default-token-id) 0 "test-uri" (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
 (expect "create a token with no concrete-policy"
   true
-  (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-policies EMPTY) ))
+  (create-token (read-msg 'empty-token-id) 0 "test-uri-1" (create-policies EMPTY) (read-keyset 'c-ks)))
 
 (expect "mint a default token with quote-policy, non-fungible-policy"
   true
@@ -137,7 +146,11 @@
 (env-sigs [
   { 'key: 'marmalade-admin
    ,'caps: []
-   }])
+   }
+  { 'key: "creation-guard"
+   ,'caps: []
+  }
+])
 
 (commit-tx)
 
@@ -146,20 +159,26 @@
 (env-sigs [
   { 'key: 'marmalade-admin
    ,'caps: []
-   }])
+   }
+  { 'key: "creation-guard"
+   ,'caps: []
+  }
+])
 (env-data {
   "ns": "marmalade-v2"
   })
   (namespace (read-msg 'ns))
   (use marmalade-v2.ledger)
   (use marmalade-v2.util-v1)
+  (env-data { 'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}})
   (env-data {
-    'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)  } )
+    'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"},
+    'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)} (read-keyset 'c-ks) )
     })
 
   (expect  "create a token "
     true
-    (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT)  ))
+    (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT) (read-keyset 'c-ks) ))
 
   (module non-fungible-policy-v1 GOVERNANCE
 
@@ -259,11 +278,12 @@
   (use marmalade-v2.util-v1)
   (env-data {
     "seller-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}
   })
   (marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
 
   (env-data {
-      "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+      "token-id": (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } (read-keyset 'c-ks) )
      ,"quote":{
         "spec": {
           "fungible": marmalade-v2.abc
@@ -290,9 +310,9 @@
   (expect "start offer by running step 0 of sale"
     "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"
     (sale (read-msg 'token-id) "k:account" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z"))))
-
+    (env-data { 'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}})
   (env-data { "seller-guard": {"keys": ["account"], "pred": "keys-all"}
-            , "token-id" : (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } )
+            , "token-id" : (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } (read-keyset 'c-ks) )
           }
   )
 
@@ -314,6 +334,7 @@
    ,"buyer": "k:buyer"
    ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
    ,"market-guard": {"keys": ["market"], "pred": "keys-all"}
+   ,'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"}
   })
 
   (marmalade-v2.abc.create-account "k:buyer" (read-keyset 'buyer-guard))
@@ -322,7 +343,7 @@
   (env-sigs
   [{'key:'buyer
     ,'caps: [
-      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } ) "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: (create-policies DEFAULT) } (read-keyset 'c-ks)) "k:account" "k:buyer" 1.0 (util.to-timestamp (time "2023-07-22T11:26:35Z")) "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg")
       (marmalade-v2.abc.TRANSFER "k:buyer" "c:DzKUkpHP-1-4XUGw1R7WLfXoWtoyICfk6hV437b_IEY" 2.0)
     ]}])
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -138,7 +138,7 @@
        0 "default-test-uri" [] ALWAYS-TRUE))
 
   (expect "create-token events"
-     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" 0 0.0 [] "default-test-uri"]}]
+     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 0 0.0 [] "default-test-uri"]}]
      (map (remove "module-hash")  (env-events true))
   )
 
@@ -151,7 +151,7 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-     "token-id": "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU"
+     "token-id": "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA"
     , "account": "k:account"
     , "account-guard": {"keys": ["account"], "pred": "keys-all"}
     })
@@ -163,7 +163,7 @@
 
    (expect-failure "enforce-mint cannot be called directly"
      "(require-capability (ledger::M...: Failure: require-capability: not granted: (marmalade-v2.ledger.MINT-CALL "
-     (enforce-mint (get-token-info "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU") (read-string 'account) (read-keyset 'account-guard ) 1.0)
+     (enforce-mint (get-token-info "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA") (read-string 'account) (read-keyset 'account-guard ) 1.0)
    )
 
   (expect "mint a default token through ledger.mint"
@@ -171,9 +171,9 @@
     (mint (read-string 'token-id )  (read-string 'account ) (read-keyset 'account-guard ) 1.0))
 
   (expect "mint events"
-    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" 1.0]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" (read-keyset 'account-guard)]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" 1.0]}
+    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0]}
     ]
    (map (remove "module-hash")  (env-events true))
   )
@@ -192,12 +192,12 @@
 
 (expect-failure "enforce-burn cannot be called directly"
  "(require-capability (ledger::B...: Failure: require-capability: not granted: (marmalade-v2.ledger.BURN-CALL"
- (enforce-burn (get-token-info "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU") (read-string 'account) 1.0)
+ (enforce-burn (get-token-info "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA") (read-string 'account) 1.0)
 )
 
 (expect "enforce-burn cannot be called directly"
   true
-  (burn "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" (read-string 'account) 1.0)
+  (burn "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" (read-string 'account) 1.0)
 )
 
 (rollback-tx)
@@ -210,7 +210,7 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-      "token-id": "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU"
+      "token-id": "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA"
      ,"seller": "k:account"
   })
 
@@ -241,12 +241,12 @@
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" "k:buyer" 1.0 0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
       ]}
   ])
 
   (env-data {
-    "token-id": "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU"
+    "token-id": "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA"
    ,"seller": "k:account"
    ,"buyer": "k:buyer"
    ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
@@ -261,10 +261,10 @@
     (continue-pact 1))
 
   (expect "buy events"
-   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" "k:buyer" 1.0 0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
-     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:buyer" (read-keyset 'buyer-guard)]}
-     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
-     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:buyer" (read-keyset 'buyer-guard)]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
@@ -289,7 +289,7 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-      "token-id": "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU"
+      "token-id": "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA"
      ,"seller": "k:account"
   })
 
@@ -327,9 +327,9 @@
     (continue-pact 0 true))
 
   (expect "withdraw events"
-   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
-     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
@@ -340,7 +340,7 @@
       ]}
     {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" "k:buyer" 1.0 0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
       ]}
   ])
 
@@ -384,7 +384,7 @@
   (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
 
   (env-data {
-      "token-id": "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU"
+      "token-id": "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA"
      ,"seller": "k:account"
      ,"quote":{
         "spec": {
@@ -427,7 +427,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" 1.0 0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" 1.0 0 (pact-id))]
     }])
 
   (expect "Withdraw succeeds"
@@ -435,9 +435,9 @@
     (continue-pact 0 true))
 
     (expect "withdraw events"
-      [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-        {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
-        {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
+      [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:account" 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}]
       (map (remove "module-hash")  (env-events true))
     )
 
@@ -448,7 +448,7 @@
       ]}
     {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" "k:buyer" 1.0 0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
       ]}
   ])
 
@@ -479,7 +479,7 @@
   (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
 
   (env-data {
-      "token-id": "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU"
+      "token-id": "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA"
      ,"seller": "k:account"
      ,"quote":{
         "spec": {
@@ -532,7 +532,7 @@
        ]}
      {'key:'buyer
        ,'caps: [
-         (marmalade-v2.ledger.BUY "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" "k:buyer" 1.0 0 (pact-id))
+         (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
        ]}
    ])
 
@@ -543,17 +543,17 @@
   (expect "buy events"
     [ {"name": "marmalade-v2.abc.TRANSFER","params": ["k:buyer-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 2.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:buyer" (read-keyset 'buyer-guard)]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" 1.0 0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" 1.0 0 (pact-id))]
     }])
 
   (expect-failure "Withdraw fails after buy has completed"
@@ -578,7 +578,7 @@
   (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
 
   (env-data {
-      "token-id": "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU"
+      "token-id": "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA"
      ,"seller": "k:account"
      ,"quote":{
         "spec": {
@@ -638,7 +638,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.WITHDRAW "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" 1.0 0 (pact-id))]
+      (marmalade-v2.ledger.WITHDRAW "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" 1.0 0 (pact-id))]
     }])
 
   (expect-failure "Withdraw fails when a sale is reserved"
@@ -648,7 +648,7 @@
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" "k:buyer" 1.0 0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
       ]}
   ])
 
@@ -675,10 +675,10 @@
       {"name": "marmalade-v2.abc.TRANSFER","params": ["k:market-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.0]}
       {"name": "marmalade-v2.policy-manager.SALE_RESERVED","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 1.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "k:buyer" (read-keyset 'buyer-guard)]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:Pde6PFsH_KcqyEpb5bs5ozENPvL5M5nECYRurHj6SEU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
 

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -138,7 +138,7 @@
        0 "default-test-uri" [] ALWAYS-TRUE))
 
   (expect "create-token events"
-     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 0 0.0 [] "default-test-uri"]}]
+     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 0 [] "default-test-uri"]}]
      (map (remove "module-hash")  (env-events true))
   )
 

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -2,6 +2,14 @@
 (load "../policy-manager/policy-manager.repl")
 (typecheck "marmalade-v2.quote-manager")
 
+(begin-tx)
+(module g-utils G
+  (defcap G() true)
+  (defun always-true:bool () true)
+  (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+)
+(commit-tx)
+
 (begin-tx "Sell token and payout royalties")
   (use marmalade-v2.ledger)
   (use marmalade-v2.policy-manager)
@@ -26,7 +34,7 @@
         ,'collection-policy: false
         ,'guard-policy: false
       })
-    }),
+    } g-utils.ALWAYS-TRUE),
     "quote": {
       "spec": {
         "seller-fungible-account": {
@@ -56,7 +64,7 @@
       ,'royalty-policy: true
       ,'collection-policy: false
       ,'guard-policy: false
-    })))
+    }) g-utils.ALWAYS-TRUE))
 
   (env-sigs [
     { 'key: 'seller
@@ -96,7 +104,7 @@
         ,'collection-policy: false
         ,'guard-policy: false
       })
-    })
+    } g-utils.ALWAYS-TRUE)
     ,"sale-id": "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"
     ,"buyer": "k:bidder"
     ,"buyer-guard": {"keys": ["bidder"], "pred": "keys-all"}

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -62,10 +62,10 @@
        (mint (read-msg 'token-id) "k:account" (read-keyset 'account-guard ) 1.0))
 
      (expect "create, mint token events"
-        [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" 0 [marmalade-v2.royalty-policy-v1] "test-quote-royalty-uri"]}
-          {"name": "marmalade-v2.ledger.MINT","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" 1.0]}
-          {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" (read-keyset 'account-guard)]}
-          {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" 1.0]}
+        [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" 0 [marmalade-v2.royalty-policy-v1] "test-quote-royalty-uri" ALWAYS-TRUE]}
+          {"name": "marmalade-v2.ledger.MINT","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" 1.0]}
+          {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" (read-keyset 'account-guard)]}
+          {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" 1.0]}
         ]
         (map (remove "module-hash")  (env-events true))
      )
@@ -78,7 +78,7 @@
   (env-hash (hash "accept-offer-with-royalties"))
 
   (env-data {
-    "token-id": "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A"
+    "token-id": "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI"
    ,"quote": {
       "spec": {
         "seller-fungible-account": {
@@ -97,7 +97,7 @@
   (env-sigs [
     { 'key: 'account
     ,'caps: [
-      (marmalade-v2.ledger.OFFER "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" 1.0 0)
+      (marmalade-v2.ledger.OFFER "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" 1.0 0)
      ]}])
 
   (expect "Offer token for sale"
@@ -107,17 +107,17 @@
   (env-data {
     "account-guard": {"keys": ["account"], "pred": "keys-all"}
    ,"market-guard": {"keys": ["market"], "pred": "keys-all"}
-   ,"token-id": "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A"
+   ,"token-id": "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI"
   })
 
   (expect "Offer with quote events"
-    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" {"amount": 1.0,"fungible": marmalade-v2.abc,"price": 10.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'account-guard )}}]}
-      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" (read-keyset 'account-guard) [(read-keyset 'market-guard)]]}
-      {"name": "marmalade-v2.ledger.OFFER","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" 1.0 0]}
-      {"name": "marmalade-v2.ledger.SALE","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" 1.0 0 "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo" (account-guard (read-string "token-id") "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo")]}
-      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo" 1.0]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo","current": 1.0,"previous": 0.0}]}]
+    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" {"amount": 1.0,"fungible": marmalade-v2.abc,"price": 10.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'account-guard )}}]}
+      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) [(read-keyset 'market-guard)]]}
+      {"name": "marmalade-v2.ledger.OFFER","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" 1.0 0]}
+      {"name": "marmalade-v2.ledger.SALE","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" 1.0 0 "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo" (account-guard (read-string "token-id") "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo","current": 1.0,"previous": 0.0}]}]
      (map (remove "module-hash")  (env-events true))
   )
 
@@ -148,7 +148,7 @@
     (marmalade-v2.quote-manager.remove-quote-guard  "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" (read-keyset 'market-guard) ))
 
    (env-data {
-      "token-id": "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A"
+      "token-id": "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI"
       ,"sale-id": "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"
       ,"buyer": "k:bidder"
       ,"buyer-guard": {"keys": ["bidder"], "pred": "keys-all"}
@@ -195,8 +195,8 @@
     (marmalade-v2.quote-manager.add-quote-guard  "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" (read-keyset 'market-guard) ))
 
   (expect "Quote guard Events"
-    [ {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" (read-keyset 'account-guard) []]}
-      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" (read-keyset 'account-guard) [ (read-keyset 'market-guard) ]]}]
+    [ {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) []]}
+      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) [ (read-keyset 'market-guard) ]]}]
      (map (remove "module-hash")  (env-events true))
   )
 
@@ -209,7 +209,7 @@
   (use marmalade-v2.util-v1)
 
   (env-data {
-      "token-id": "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A"
+      "token-id": "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI"
      ,"sale-id": "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"
      ,"bidder": "k:bidder"
      ,"buyer": "k:buyer"
@@ -234,13 +234,13 @@
   (env-sigs [
      { 'key: 'any
      ,'caps: [
-         (marmalade-v2.ledger.BUY "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" "k:buyer"  1.0 0 (read-string 'sale-id))
+         (marmalade-v2.ledger.BUY "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" "k:buyer"  1.0 0 (read-string 'sale-id))
        ]
      }
    ])
 
  (env-data {
-     "token-id": "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A"
+     "token-id": "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI"
     ,"sale-id": "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"
     ,"buyer": "k:buyer1"
     ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
@@ -251,7 +251,7 @@
     (continue-pact 1 false (read-msg 'sale-id)))
 
   (env-data {
-      "token-id": "t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A"
+      "token-id": "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI"
      ,"sale-id": "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"
      ,"buyer": "k:buyer"
      ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -62,7 +62,7 @@
        (mint (read-msg 'token-id) "k:account" (read-keyset 'account-guard ) 1.0))
 
      (expect "create, mint token events"
-        [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" 0 0.0 [marmalade-v2.royalty-policy-v1] "test-quote-royalty-uri"]}
+        [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" 0 [marmalade-v2.royalty-policy-v1] "test-quote-royalty-uri"]}
           {"name": "marmalade-v2.ledger.MINT","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" 1.0]}
           {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" "k:account" (read-keyset 'account-guard)]}
           {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:fWW9MREEYVY0tJxjx-_1C-5pDTMZ9qKxC4Zs-XHWY4A" 1.0]}


### PR DESCRIPTION
This pr takes in the changes from https://github.com/kadena-io/marmalade/pull/125. It uses a guard in the generation of the tokenId that is enforced during token-creation. However we’ve adapted the changes in the following areas:

- We kept the chain_id as part of the token-id generation mechanism. Including the chain_id fits with Kadena’s planned multi chain approach, details of which will follow later.
- Introduced a capability on token creation to sign, we don’t want to promote unrestricted signing
- Updated to be compatible with latest v2 changes
