### PR TITLE
Restrict royalty-policy-v1 to support `coin` only

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -10,7 +10,7 @@
   (env-data {
     "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
   })
-  (marmalade-v2.abc.create-account "k:creator" (read-keyset 'creator-guard))
+  (coin.create-account "k:creator" (read-keyset 'creator-guard))
 (commit-tx)
 
 (begin-tx "Creating collection fails without operator guard")
@@ -35,7 +35,7 @@
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
-      "fungible": marmalade-v2.abc
+      "fungible": coin
     ,"creator": "k:creator"
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05
@@ -129,7 +129,7 @@
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
-      "fungible": marmalade-v2.abc
+      "fungible": coin
     ,"creator": "k:creator"
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05
@@ -172,7 +172,7 @@
   ,"account": "k:account"
   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
   ,"royalty_spec": {
-      "fungible": marmalade-v2.abc
+      "fungible": coin
     ,"creator": "k:creator"
     ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
     ,"royalty-rate": 0.05

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -56,6 +56,7 @@
             (royalty-rate:decimal (at 'royalty-rate spec))
             (creator-details:object (fungible::details creator ))
             )
+      (enforce (= fungible coin) "Royalty support is restricted to coin")
       (enforce (=
         (at 'guard creator-details) creator-guard)
         "Creator guard does not match")

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -14,6 +14,10 @@
 (marmalade-v2.abc.create-account "k:creator" (read-keyset 'creator-guard))
 (marmalade-v2.abc.create-account "k:badactor" (read-keyset 'bad-actor-guard))
 
+(coin.create-account "k:creator" (read-keyset 'creator-guard))
+(coin.create-account "k:badactor" (read-keyset 'bad-actor-guard))
+
+
 (commit-tx)
 (begin-tx)
 (use marmalade-v2.ledger)
@@ -27,18 +31,32 @@
     "fungible": marmalade-v2.abc
    ,"creator": "k:creator"
    ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
-   ,"royalty-rate": -0.000001
+   ,"royalty-rate": 0.000001
   }
 })
 
-(env-keys ['marmalade-admin ])
 
-(commit-tx)
+(expect-failure "create-token with royalty_spec with fungible other than coin fails"
+  "Royalty support is restricted to coin"
+  (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ))
+
+(rollback-tx)
 
 (begin-tx)
 (use marmalade-v2.ledger)
-
 (use marmalade-v2.util-v1)
+
+(env-data {
+  "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} )
+ ,"account": "account"
+ ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+ ,"royalty_spec": {
+    "fungible": coin
+   ,"creator": "k:creator"
+   ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
+   ,"royalty-rate": -0.000001
+  }
+})
 
 (expect-failure "create-token with negative royalty rate fails"
   "Invalid royalty rate"
@@ -47,7 +65,6 @@
 
 (begin-tx)
 (use marmalade-v2.ledger)
-
 (use marmalade-v2.util-v1)
 
 (env-data {
@@ -55,7 +72,7 @@
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
-    "fungible": marmalade-v2.abc
+    "fungible": coin
    ,"creator": "k:creator"
    ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty-rate": 0.05
@@ -86,7 +103,7 @@
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
-    "fungible": marmalade-v2.abc
+    "fungible": coin
    ,"creator": "k:badactor"
    ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty-rate": 0.05
@@ -125,7 +142,7 @@
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
-    "fungible": marmalade-v2.abc
+    "fungible": coin
    ,"creator": "k:creator"
    ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty-rate": 1
@@ -142,7 +159,7 @@
  ,"account": "k:account"
  ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
  ,"royalty_spec": {
-    "fungible": marmalade-v2.abc
+    "fungible": coin
    ,"creator": "k:creator"
    ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty-rate": 2.0
@@ -166,7 +183,7 @@
   "seller-guard": {"keys": ["account"], "pred": "keys-all"}
 })
 
-(marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
+(coin.create-account "k:account" (read-keyset 'seller-guard))
 (marmalade-v2.def.create-account "k:account" (read-keyset 'seller-guard))
 
 (env-data {
@@ -194,14 +211,14 @@
    }])
 
 (expect-failure "Offer fails when quote uses a different fungible from registered fungible"
-  "(enforce (= fungible (at 'fung...: Failure: Tx Failed: Offer is restricted to sale using fungible: marmalade-v2.abc"
+  "(enforce (= fungible (at 'fung...: Failure: Tx Failed: Offer is restricted to sale using fungible: coin"
   (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
 
 (env-data {
   "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
   ,"quote":{
      "spec": {
-       "fungible": marmalade-v2.abc
+       "fungible": coin
        ,"price": 2.0
        ,"amount": 1.0
        ,"seller-fungible-account": {
@@ -225,13 +242,13 @@
   "seller-guard": {"keys": ["account"], "pred": "keys-all"}
 })
 
-(marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
+(coin.create-account "k:account" (read-keyset 'seller-guard))
 
 (env-data {
   "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } )
   ,"quote":{
      "spec": {
-       "fungible": marmalade-v2.abc
+       "fungible": coin
        ,"price": 2.0
        ,"amount": 1.0
        ,"seller-fungible-account": {
@@ -263,23 +280,23 @@
  ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
  })
 
-(marmalade-v2.abc.create-account "k:buyer" (read-keyset 'buyer-guard))
-(marmalade-v2.abc.fund "k:buyer" 2.0)
+(test-capability (coin.COINBASE))
+(coin.coinbase "k:buyer" (read-keyset 'buyer-guard) 2.0)
 
 (env-sigs
  [{'key:'buyer
   ,'caps: [
     (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ) "k:account" "k:buyer"  1.0 (to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
-    (marmalade-v2.abc.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
+    (coin.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
    ]}])
 
  (expect
    "Expect k:buyer balance to be correct"
-   2.0 (marmalade-v2.abc.get-balance "k:buyer"))
+   2.0 (coin.get-balance "k:buyer"))
 
  (expect
    "Expect vault creator balance to be correct"
-   0.0 (marmalade-v2.abc.get-balance "k:creator"))
+   0.0 (coin.get-balance "k:creator"))
 
 (env-hash (hash "offer-royalty-0"))
 
@@ -289,11 +306,11 @@
 
 (expect
   "Expect k:buyer balance to be correct"
-  0.0 (marmalade-v2.abc.get-balance "k:buyer"))
+  0.0 (coin.get-balance "k:buyer"))
 
 (expect
   "Expect creator balance to be correct"
-  0.1 (marmalade-v2.abc.get-balance "k:creator"))
+  0.1 (coin.get-balance "k:creator"))
 
 
 (env-data {

--- a/pact/marmalade.repl
+++ b/pact/marmalade.repl
@@ -5,6 +5,7 @@
     , 'ns-operate-keyset:[] })
   (load "./root/fungible-v2.pact")
   (load "./root/fungible-xchain-v1.pact")
+  (load "./root/coin.pact")
   (load "./root/gas-payer-v1.pact")
   (env-exec-config ["DisablePact44"])
   (load "./root/ns.pact")

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -11,10 +11,11 @@
     "creator-guard": {"keys": ["creator"], "pred": "keys-all"},
     "bidder-guard": {"keys": ["bidder"], "pred": "keys-all"}
   })
-  (marmalade-v2.abc.create-account "k:account" (read-keyset 'seller-guard))
-  (marmalade-v2.abc.create-account "k:creator" (read-keyset 'creator-guard))
-  (marmalade-v2.abc.create-account "k:bidder" (read-keyset 'bidder-guard))
-  (marmalade-v2.abc.fund "k:bidder" 25.0)
+  (coin.create-account "k:account" (read-keyset 'seller-guard))
+  (coin.create-account "k:creator" (read-keyset 'creator-guard))
+  (coin.create-account "k:bidder" (read-keyset 'bidder-guard))
+  (test-capability (coin.COINBASE))
+  (coin.coinbase "k:bidder" (read-keyset 'bidder-guard) 25.0)
 (commit-tx)
 
 (begin-tx "Create add mint token with royalties")
@@ -33,7 +34,7 @@
         })
       })
      ,"royalty_spec": {
-        "fungible": marmalade-v2.abc
+        "fungible": coin
         ,"creator": "k:creator"
         ,"creator-guard":  {"keys": ["creator"], "pred": "keys-all"}
         ,"royalty-rate": 0.05
@@ -84,7 +85,7 @@
             "account": "k:account"
            ,"guard": {"keys": ["account"], "pred": "keys-all"}
           }
-        ,"fungible": marmalade-v2.abc
+        ,"fungible": coin
         ,"price": 10.0
         ,"amount": 1.0
         }
@@ -110,7 +111,7 @@
   })
 
   (expect "Offer with quote events"
-    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" {"amount": 1.0,"fungible": marmalade-v2.abc,"price": 10.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'account-guard )}}]}
+    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" {"amount": 1.0,"fungible": coin,"price": 10.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'account-guard )}}]}
       {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" (read-keyset 'account-guard) [(read-keyset 'market-guard)]]}
       {"name": "marmalade-v2.ledger.OFFER","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" 1.0 0]}
       {"name": "marmalade-v2.ledger.SALE","params": ["t:JlLcrX-v00nuzRF8HUxhPRtUgWUFBpj_4cDmFnpOtfQ" "k:account" 1.0 0 "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"]}
@@ -217,7 +218,7 @@
    (env-sigs [
       { 'key: 'bidder
       ,'caps: [
-          (marmalade-v2.abc.TRANSFER "k:bidder" "c:yk0ICQ5W7xvtcDUaXSOyBYD4nMKhm-GXdVxY1mC0PQs" 20.0)
+          (coin.TRANSFER "k:bidder" "c:yk0ICQ5W7xvtcDUaXSOyBYD4nMKhm-GXdVxY1mC0PQs" 20.0)
       ]}
       { 'key: 'market
       ,'caps: [
@@ -261,10 +262,10 @@
 
   (expect "Seller account has increased with 20 tokens minus royalty fees"
     19.0
-    (marmalade-v2.abc.get-balance "k:account"))
+    (coin.get-balance "k:account"))
 
   (expect "Creator account has received 5% royalties"
     1.0
-    (marmalade-v2.abc.get-balance "k:creator"))
+    (coin.get-balance "k:creator"))
 
 (rollback-tx)


### PR DESCRIPTION
Implementation of royalties with `royalty-policy-v1` limits marmalade tokens to only be traded with the registered fungibles. 
To prevent misuse of malformed fungible or fungible contract that upgrades to be disabled mentioned in the comment (https://github.com/kadena-io/marmalade/issues/127#issuecomment-1700283058), the first version of the royalty-policy-v1 will enforce fungible to use `coin` in the royalty-spec. 

In later upgrades, we will decide different ways to support multiple fungibles for royalties. 
Closes #127  