### PR TITLE
Refine Capability Names

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.md
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.md
@@ -3,16 +3,16 @@
 
 The Collection Policy is a module that manages the creation and management of collections of tokens. It's a concrete policy that displays the simplicity of creating collections with Marmalade v2. In Marmalade v1 there was a collection policy that included a whitelist. This functionality is removed in v2, and will become a separate policy.  Its good to know that like all concrete policies the module implements the `kip.token-policy-v2` interface, which defines the standard interface that token policies must implement.
 
-
 ## Specification, tables, capabilities:
-
 
 **Schemas**: `collection` and `token` schemas that store information related to collections and the tokens within them.
 
 **Tables**: `collections` and `tokens` tables that store the collections and token information, respectively.
 
-**Capabilities**: `GOVERNANCE` and `OPERATOR` capabilities that enforce access control.
-
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrade.
+ - `COLLECTION` @event: enforces access control of the collection creation and emits event for discovery
+ - `TOKEN-COLLECTION` @event: enforces access control of the token collection creation and emits event for discovery
 
 ## Policy Functions
 

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -31,22 +31,20 @@
 
   (defconst COLLECTION-ID-MSG-KEY:string "collection_id")
 
-  (defcap OPERATOR (collection-id:string)
-    @doc "Capability to grant creation of a collection's token"
+  (defcap COLLECTION:bool (collection-id:string collection-name:string collection-size:integer operator-guard:guard)
+    @doc "Capability to grant creation of a collection and emit COLLECTION event for discovery"
+    @event
+    (enforce-guard operator-guard)
+  )
+
+  (defcap TOKEN-COLLECTION (collection-id:string token-id:string)
+    @doc "Capability to grant creation of a collection's token and emit TOKEN-COLLECTION event for discovery"
+    @event
     (with-read collections collection-id {
       'operator-guard:= operator-guard:guard
       }
       (enforce-guard operator-guard))
   )
-
-  (defcap COLLECTION:bool (collection-id:string collection-name:string collection-size:integer operator-guard:guard)
-    @event
-    (enforce-guard operator-guard)
-  )
-
-  (defcap TOKEN_COLLECTION:bool (token-id:string collection-id:string)
-    @event
-    true)
 
   (defun create-collection:bool
     ( collection-name:string
@@ -73,12 +71,12 @@
     @doc "Executed at `create-token` step of marmalade.ledger.                 \
     \ Required msg-data keys:                                                  \
     \ * collection_id:string - registers the token to a collection and emits   \
-    \ TOKEN_COLLECTION event for discovery"
+    \ TOKEN-COLLECTION event for collection token discovery"
     (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) collection-policy-v1))
     (let* ( (token-id:string  (at 'id token))
             (collection-id:string (read-msg COLLECTION-ID-MSG-KEY)) )
     ;;Enforce operator guard
-    (with-capability (OPERATOR collection-id)
+    (with-capability (TOKEN-COLLECTION collection-id token-id)
       (with-read collections collection-id {
         "max-size":= max-size
        ,"size":= size
@@ -94,8 +92,8 @@
         { "id" : token-id
          ,"collection-id" : collection-id
       })
+      )
     )
-    (emit-event (TOKEN_COLLECTION token-id collection-id)))
     true
   )
 

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -15,12 +15,12 @@
   (use marmalade-v2.util-v1)
   (use mini-guard-utils)
   (env-data {
-    "ks": {"keys": ["operator"], "pred": "keys-all"}
+    "operator": {"keys": ["operator"], "pred": "keys-all"}
   })
 
  (expect-failure "create collection fails if operator guard isn't present"
     "Keyset failure"
-    (marmalade-v2.collection-policy-v1.create-collection "test-collection0" 10 (read-keyset 'ks )))
+    (marmalade-v2.collection-policy-v1.create-collection "test-collection0" 10 (read-keyset 'operator )))
 (rollback-tx)
 
 (begin-tx "Creating collection")
@@ -39,21 +39,26 @@
     ,"royalty-rate": 0.05
     }
   ,"collection_id": "collection:lUAvkHxqGSH22Z7zLMljdmHlFZ-DvfuVYdC0ioHCfqk"
-  ,"ks": {"keys": ["operator"], "pred": "keys-all"}
+  ,"operator": {"keys": ["operator"], "pred": "keys-all"}
   })
 
   (expect "collection id generation based on name and operator"
     "collection:lUAvkHxqGSH22Z7zLMljdmHlFZ-DvfuVYdC0ioHCfqk"
-    (marmalade-v2.collection-policy-v1.create-collection-id "test-collection0" (read-keyset 'ks )))
+    (marmalade-v2.collection-policy-v1.create-collection-id "test-collection0" (read-keyset 'operator )))
 
   (env-sigs [
     { 'key: 'operator
-    ,'caps: [(marmalade-v2.collection-policy-v1.COLLECTION "collection:lUAvkHxqGSH22Z7zLMljdmHlFZ-DvfuVYdC0ioHCfqk" "test-collection0" 10 (read-keyset 'ks ))]
+    ,'caps: [(marmalade-v2.collection-policy-v1.COLLECTION "collection:lUAvkHxqGSH22Z7zLMljdmHlFZ-DvfuVYdC0ioHCfqk" "test-collection0" 10 (read-keyset 'operator ))]
     }])
 
   (expect "initiate a collection with `create-collection`"
     true
-    (marmalade-v2.collection-policy-v1.create-collection "test-collection0" 10 (read-keyset 'ks )))
+    (marmalade-v2.collection-policy-v1.create-collection "test-collection0" 10 (read-keyset 'operator )))
+
+  (expect "create-collection events"
+    [ {"name": "marmalade-v2.collection-policy-v1.COLLECTION","params": ["collection:lUAvkHxqGSH22Z7zLMljdmHlFZ-DvfuVYdC0ioHCfqk" "test-collection0" 10 (read-keyset 'operator)]}]
+    (map (remove "module-hash")  (env-events true))
+  )
 (commit-tx)
 
 (begin-tx "Create token without operator guard fails")
@@ -77,13 +82,20 @@
 
   (env-sigs [
     { 'key: 'operator
-    ,'caps: [(marmalade-v2.collection-policy-v1.OPERATOR "collection:lUAvkHxqGSH22Z7zLMljdmHlFZ-DvfuVYdC0ioHCfqk")]
+    ,'caps: [(marmalade-v2.collection-policy-v1.TOKEN-COLLECTION "collection:lUAvkHxqGSH22Z7zLMljdmHlFZ-DvfuVYdC0ioHCfqk" (read-msg 'token-id) )]
     }])
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
     (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
 
+  (expect "create-token events"
+     [ {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:e83TzCt8iPa0O8nZXRzq32_BoJ54mhZuWc5SlAC_85I" (read-msg 'royalty_spec)]}
+       {"name": "marmalade-v2.collection-policy-v1.TOKEN-COLLECTION","params": ["collection:lUAvkHxqGSH22Z7zLMljdmHlFZ-DvfuVYdC0ioHCfqk" "t:e83TzCt8iPa0O8nZXRzq32_BoJ54mhZuWc5SlAC_85I"]}
+       {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:e83TzCt8iPa0O8nZXRzq32_BoJ54mhZuWc5SlAC_85I" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+       {"name": "marmalade-v2.ledger.TOKEN","params": ["t:e83TzCt8iPa0O8nZXRzq32_BoJ54mhZuWc5SlAC_85I" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.collection-policy-v1 marmalade-v2.guard-policy-v1] "test-collection-royalty-uri" ALWAYS-TRUE]} ]
+    (map (remove "module-hash")  (env-events true))
+  )
 (commit-tx)
 
 (begin-tx "Mint token without mint-guard fails")
@@ -105,7 +117,7 @@
       ,"name": "test-collection0"
       ,"size": 1
       ,"max-size": 10
-      ,"operator-guard": (read-keyset 'ks )
+      ,"operator-guard": (read-keyset 'operator )
     }
     (marmalade-v2.collection-policy-v1.get-collection (read-msg 'collection_id)))
 
@@ -116,6 +128,15 @@
     }
     (marmalade-v2.collection-policy-v1.get-token (read-msg 'token-id))
   )
+
+  (expect "mint events"
+     [ {"name": "marmalade-v2.ledger.MINT","params": ["t:e83TzCt8iPa0O8nZXRzq32_BoJ54mhZuWc5SlAC_85I" "k:account" 1.0]}
+       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:e83TzCt8iPa0O8nZXRzq32_BoJ54mhZuWc5SlAC_85I" "k:account" (read-keyset 'account-guard)]}
+       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:e83TzCt8iPa0O8nZXRzq32_BoJ54mhZuWc5SlAC_85I" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}
+       {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:e83TzCt8iPa0O8nZXRzq32_BoJ54mhZuWc5SlAC_85I" 1.0]} ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
 (commit-tx)
 
 (begin-tx "Creating collection and validate size")
@@ -136,21 +157,22 @@
     ,"royalty-rate": 0.05
     }
   ,"collection_id": "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8"
-  ,"ks": {"keys": ["operator"], "pred": "keys-all"}
+  ,"operator": {"keys": ["operator"], "pred": "keys-all"}
   })
 
   (env-sigs [
       { 'key: 'operator
-      ,'caps: [(marmalade-v2.collection-policy-v1.COLLECTION "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "test-collection-size" 1 (read-keyset 'ks ))]
+      ,'caps: [(marmalade-v2.collection-policy-v1.COLLECTION "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "test-collection-size" 1 (read-keyset 'operator ))]
       }])
 
   (expect "initiate a collection with `create-collection`"
     true
-    (marmalade-v2.collection-policy-v1.create-collection "test-collection-size" 1 (read-keyset 'ks )))
+    (marmalade-v2.collection-policy-v1.create-collection "test-collection-size" 1 (read-keyset 'operator )))
 
   (env-sigs [
     { 'key: 'operator
-    ,'caps: [(marmalade-v2.collection-policy-v1.OPERATOR "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8")]
+    ,'caps: [(marmalade-v2.collection-policy-v1.TOKEN-COLLECTION "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" (read-msg 'token-id1))
+             (marmalade-v2.collection-policy-v1.TOKEN-COLLECTION "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" (read-msg 'token-id2))]
     }])
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
@@ -160,6 +182,15 @@
   (expect-failure "creating another token will exceed collection-size"
     "Exceeds collection size"
     (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
+
+
+  (expect "create-collection, create-token events"
+    [ {"name": "marmalade-v2.collection-policy-v1.COLLECTION","params": ["collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "test-collection-size" 1 (read-keyset 'operator)]}
+      {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:tNiX3x5wudNYsplHqy8P98j8UPHF8XX2n4G7-nXiMt8" (read-msg 'royalty_spec)] }
+      {"name": "marmalade-v2.collection-policy-v1.TOKEN-COLLECTION","params": ["collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "t:tNiX3x5wudNYsplHqy8P98j8UPHF8XX2n4G7-nXiMt8"]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:tNiX3x5wudNYsplHqy8P98j8UPHF8XX2n4G7-nXiMt8" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:tNiX3x5wudNYsplHqy8P98j8UPHF8XX2n4G7-nXiMt8" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.collection-policy-v1 marmalade-v2.guard-policy-v1] "test-collection-size-uri1" ALWAYS-TRUE]}]
+    (map (remove "module-hash")  (env-events true)))
 (rollback-tx)
 
 (begin-tx "Create collection with unlimited size and add two tokens")
@@ -180,21 +211,22 @@
     ,"royalty-rate": 0.05
     }
   ,"collection_id": "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8"
-  ,"ks": {"keys": ["operator"], "pred": "keys-all"}
+  ,"operator": {"keys": ["operator"], "pred": "keys-all"}
   })
 
   (env-sigs [
       { 'key: 'operator
-      ,'caps: [(marmalade-v2.collection-policy-v1.OPERATOR "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8")],'caps: [(marmalade-v2.collection-policy-v1.COLLECTION "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "test-collection-size" 0 (read-keyset 'ks ))]
+      ,'caps: [(marmalade-v2.collection-policy-v1.OPERATOR "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8")],'caps: [(marmalade-v2.collection-policy-v1.COLLECTION "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "test-collection-size" 0 (read-keyset 'operator ))]
       }])
 
   (expect "initiate a collection with `create-collection`"
     true
-    (marmalade-v2.collection-policy-v1.create-collection "test-collection-size" 0 (read-keyset 'ks )))
+    (marmalade-v2.collection-policy-v1.create-collection "test-collection-size" 0 (read-keyset 'operator )))
 
   (env-sigs [
       { 'key: 'operator
-      ,'caps: [(marmalade-v2.collection-policy-v1.OPERATOR "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8")]
+      ,'caps: [(marmalade-v2.collection-policy-v1.TOKEN-COLLECTION "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" (read-msg 'token-id1))
+               (marmalade-v2.collection-policy-v1.TOKEN-COLLECTION "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" (read-msg 'token-id2))]
       }])
 
   (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
@@ -204,4 +236,16 @@
   (expect "create another token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
     true
     (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
+
+  (expect "create-collection, create-token events"
+    [ {"name": "marmalade-v2.collection-policy-v1.COLLECTION","params": ["collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "test-collection-size" 0 (read-keyset 'operator)]}
+      {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:tNiX3x5wudNYsplHqy8P98j8UPHF8XX2n4G7-nXiMt8" (read-msg 'royalty_spec) ]}
+      {"name": "marmalade-v2.collection-policy-v1.TOKEN-COLLECTION","params": ["collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "t:tNiX3x5wudNYsplHqy8P98j8UPHF8XX2n4G7-nXiMt8"]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:tNiX3x5wudNYsplHqy8P98j8UPHF8XX2n4G7-nXiMt8" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:tNiX3x5wudNYsplHqy8P98j8UPHF8XX2n4G7-nXiMt8" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.collection-policy-v1 marmalade-v2.guard-policy-v1] "test-collection-size-uri1" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:Y7TEGb0F0SUF5EFShV0jaewJcpfioGMrElU6YCFWW1I" (read-msg 'royalty_spec) ]}
+      {"name": "marmalade-v2.collection-policy-v1.TOKEN-COLLECTION","params": ["collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8" "t:Y7TEGb0F0SUF5EFShV0jaewJcpfioGMrElU6YCFWW1I"]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:Y7TEGb0F0SUF5EFShV0jaewJcpfioGMrElU6YCFWW1I" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:Y7TEGb0F0SUF5EFShV0jaewJcpfioGMrElU6YCFWW1I" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.collection-policy-v1 marmalade-v2.guard-policy-v1] "test-collection-size-uri2" ALWAYS-TRUE]}]
+    (map (remove "module-hash")  (env-events true)))
 (rollback-tx)

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -27,9 +27,10 @@
   (defconst GUARD_SUCCESS:guard (create-user-guard (success)))
   (defconst GUARD_FAILURE:guard (create-user-guard (failure)))
 
-  (defcap GUARDS:object{guards} (guards:object{guards})
+  (defcap GUARDS:bool (token-id:string guards:object{guards})
+    @doc "Emits event for discovery"
     @event
-    guards
+    true
   )
 
   (defcap MINT (token-id:string account:string amount:decimal)
@@ -112,7 +113,7 @@
       , 'transfer-guard: (try GUARD_SUCCESS (read-msg TRANSFER-GUARD-MSG-KEY) ) } ))
     (insert policy-guards (at 'id token)
       guards)
-    (emit-event (GUARDS guards)) )
+    (emit-event (GUARDS (at "id" token) guards)) )
     true
   )
 

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -1,9 +1,10 @@
 ;;load policy manager, ledger
 (load "../../policy-manager/policy-manager.repl")
-(typecheck "marmalade-v2.non-fungible-policy-v1")
+(typecheck "marmalade-v2.guard-policy-v1")
 
 (begin-tx "Create token without mint guard")
     (use marmalade-v2.ledger)
+    (use marmalade-v2.guard-policy-v1)
     (use marmalade-v2.util-v1)
     (use mini-guard-utils)
   (env-data {
@@ -18,17 +19,26 @@
     }])
 
   (expect "create token succeeds without mint-guard"
-   true
-   (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ALWAYS-TRUE))
+    true
+    (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ALWAYS-TRUE))
 
   (expect "Mint token succeeds without mint-guard"
     true
     (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
 
+  (expect "create-token, mint events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "test-default-guard" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.ledger.MINT","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" "k:account" (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+
 (rollback-tx)
 
 (begin-tx "Create token without operator guard fails")
   (use marmalade-v2.ledger)
+  (use marmalade-v2.guard-policy-v1)
   (use marmalade-v2.util-v1)
   (use mini-guard-utils)
   (env-data {
@@ -63,4 +73,12 @@
     true
     (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
 
+  (expect "create-token, mint events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" {"burn-guard": GUARD_SUCCESS,"mint-guard": (read-keyset 'mint_guard),"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "test-default-guard" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.ledger.MINT","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" "k:account" (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}
+      {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
 (rollback-tx)

--- a/pact/concrete-policies/guard-policy/guard-policy.md
+++ b/pact/concrete-policies/guard-policy/guard-policy.md
@@ -1,18 +1,40 @@
-# guard-policy tutorial
+# Guard Policy
 
 guard-policy is a policy that defines several functions that enforce rules on various token-related actions such as minting, burning, transferring, and buying/selling tokens. The policy defines a schema for guards which includes keysets for various actions.
 
-A table:policy-guards contains the mapped token IDs to guard values for that token. Additionally.
+## Specification, tables, capabilities:
 
-The enforce-ledger function is used to enforce the marmalade.ledger.ledger-guard guard, which appears to ensure that only authorized parties can make changes to the ledger.
 
-The enforce-init function initializes the policy-guards table for a given token ID with the appropriate guard values.
+**Schemas**: `guards` schemas that store `mint`, `burn`, `sale`, `transfer` guards
 
-The enforce-offer and enforce-buy functions enforce rules related to buying and selling tokens, including checking the sale-id against the currently executing pact.
+**Tables**: `policy-guards` table that store the mapped token IDs to guard values for that token.
 
-The enforce-transfer function enforce rules related to transferring tokens, including checking the sender, receiver, and amount of the transfer against the specified guards.
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrade.
+ - `GUARDS` @event: emits token's guard information at `enforce-init`
+ - `MINT`: enforces the registered `mint-guard` at `enforce-mint`
+ - `BURN`: enforces the registered `burn-guard` at `enforce-burn`
+ - `SALE`:  enforces the registered `sale-guard` at `enforce-offer`, `enforce-withdraw`, `enforce-buy`
+ - `TRANSFER` : enforces the registered `sale-guard` at `enforce-transfer`
+
+## Policy Functions
+
+**enforce-init**: initializes the policy-guards table for a given token ID with the appropriate guard values.
+
+**enforce-mint**: enforces mint guards
+
+**enforce-burn**: enforces burn guards
+
+**enforce-offer**: enforces sale guards and checks the sale-id against the currently executing pact.
+
+**enforce-withdraw**: enforces sale guards, and checks the sale-id against the currently executing pact.
+
+**enforce-buy**: enforces sale guards, and checks the sale-id against the currently executing pact.
+
+**enforce-transfer**: enforce transfer guards, including checking the sender, receiver, and amount of the transfer.
 
 Finally, the code includes a conditional block that creates the policy-guards table if it does not already exist, or returns a message indicating that the upgrade is complete if the table does exist.
+
 
 ## Mint Guards
 

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.md
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.md
@@ -6,14 +6,10 @@ The `non-fungible-policy-v1` facilitates the creation and management of non-fung
 
 ## Specifications and Tables:
 
-
 **Policy functions**: Several functions that enforce specific rules for token-related actions.
 
-**Mint Guards Specification**: The `mint-guard-schema` is a schema designed to store information related to mint guards for non-fungible tokens.
-
-**Mint Guards Table**: A table, `mintguards`, is created to store the mint guard information for each non-fungible token (NFT), including the token ID and its associated mint guard. This table ensures proper authorization and control over the minting process, preserving the unique properties of the NFTs managed under the policy.
-
-
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrade.
 
 ## Policy Functions
 

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -41,13 +41,15 @@
     ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
   })
 
-(expect-failure  "Precision should be 0"
-  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) ALWAYS-TRUE))
+  (expect-failure  "Precision should be 0"
+    (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) ALWAYS-TRUE))
+
 (rollback-tx)
 
 
-(begin-tx)
+(begin-tx "Create a non-fungible token")
   (use marmalade-v2.ledger)
+  (use marmalade-v2.guard-policy-v1)
   (use marmalade-v2.util-v1)
   (use mini-guard-utils)
   (env-data {
@@ -56,15 +58,15 @@
     ,"mint-guard": {"keys": ["account"], "pred": "keys-all"}
   })
 
-(commit-tx)
+(expect  "create-token succeeds with non-fungible-policy"
+   true
+  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) ALWAYS-TRUE))
 
-(begin-tx "Create a non-fungible token")
-  (use marmalade-v2.ledger)
-  (use marmalade-v2.util-v1)
-  (use mini-guard-utils)
-  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) ALWAYS-TRUE)
+(expect "create-token events"
+   [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:zJEj9yNd9xDzlubDN2saEJxu5_iYYPnZ8kZhWYhE6QE" {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS}]}
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:zJEj9yNd9xDzlubDN2saEJxu5_iYYPnZ8kZhWYhE6QE" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "test-non-fungible-uri" ALWAYS-TRUE]}]
+  (map (remove "module-hash")  (env-events true)))
 (commit-tx)
-
 
 (begin-tx "Mint with a supply other then 1 fails ")
 
@@ -78,6 +80,7 @@
   (expect-failure "minting with amount of 5 fails"
     "Mint can only be 1"
     (mint (read-msg "token-id" )  (read-msg "account" ) (read-keyset "mint-guard" ) 5.0))
+
 (commit-tx)
 
 (begin-tx "Mint with a fractional amount fails ")
@@ -104,16 +107,23 @@
   (expect "minting succeeds"
     true
     (mint (read-msg "token-id" )  (read-msg "account" ) (read-keyset "mint-guard" ) 1.0))
+
+  (expect "mint events"
+   [ {"name": "marmalade-v2.ledger.MINT","params": ["t:zJEj9yNd9xDzlubDN2saEJxu5_iYYPnZ8kZhWYhE6QE" "k:account" 1.0]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:zJEj9yNd9xDzlubDN2saEJxu5_iYYPnZ8kZhWYhE6QE" "k:account" (read-keyset 'mint-guard)]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:zJEj9yNd9xDzlubDN2saEJxu5_iYYPnZ8kZhWYhE6QE" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]}
+     {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:zJEj9yNd9xDzlubDN2saEJxu5_iYYPnZ8kZhWYhE6QE" 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
 (commit-tx)
 
 (begin-tx "Burn a non-fungible token")
   (use marmalade-v2.ledger)
-    (env-sigs [
-      { 'key: 'account
-      ,'caps: [(marmalade-v2.ledger.BURN (read-msg 'token-id) "k:account" 1.0)]
-      }])
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [(marmalade-v2.ledger.BURN (read-msg 'token-id) "k:account" 1.0)]
+    }])
 
-    (expect-failure "Burning is not allowed"
-      "Burn prohibited"
-      (burn (read-msg "token-id" )  (read-msg "account" ) 1.0))
+  (expect-failure "Burning is not allowed"
+    "Burn prohibited"
+    (burn (read-msg "token-id" )  (read-msg "account" ) 1.0))
 (commit-tx)

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.md
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.md
@@ -3,7 +3,7 @@
 
 This policy, `royalty-policy-v1`, is designed to support royalty payouts during the sale of non-fungible token. It implements the `kip.token-policy-v2` interface and extends the functionality provided by the base policy.
 
-  
+
 ## Specifications and Tables:
 
 **Policy functions**: Several functions that enforce specific rules for token-related actions.
@@ -11,7 +11,12 @@ This policy, `royalty-policy-v1`, is designed to support royalty payouts during 
 **Royalty Specification**: The `royalty-schema` is a schema designed to store information related to royalties for non-fungible tokens, such as the creator, creator guard, royalty rate, and associated fungible token.
 
 **Royalties Table**: A table, `royalties`, is created to store the royalty information for each non-fungible token (NFT), including the token ID and its associated royalty details. This table ensures proper handling of royalty payouts during token sales and maintains a record of royalty configurations for the NFTs managed under the policy.
-  
+
+
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrade.
+ - `ROYALTY` @event: emits the token-id and registered royalty information at `enforce-init`
+ - `ROYALTY-PAYOUT` @event: emits royalty payout information `enforce-buy` if royalty was paid.
 
 ## Policy Functions
 
@@ -24,7 +29,7 @@ This policy, `royalty-policy-v1`, is designed to support royalty payouts during 
 
 To use the `royalty-policy-v1` , enable it by setting it to `true` within the concrete policies list.
 
- 
+
 ## Payload messages
 
 
@@ -35,10 +40,10 @@ The `enforce-init` function initialises a royalty for a fungible token and enfor
 
 The `fungible` field specifies the module that contains the fungible token. The `creator` field specifies the creator of the token. The `creator-guard` field specifies a guard that must be satisfied by the creator's details. The `royalty-rate` field specifies the percentage of the sale price that will be charged as a royalty. The `quote-policy` field specifies the policy module that contains the quote policy.
 
-  
+
 Once the `royalty-schema` object has been read from the message payload, the function extracts the relevant fields from it and performs several checks to ensure the validity of the royalty. It then inserts the royalty into the `royalties` database.
 
- 
+
 ## Events
 
 
@@ -56,9 +61,8 @@ Once the `royalty-schema` object has been read from the message payload, the fun
 
 
 #### `ROYALTY` Event
-  
-The ROYALTY event is emitted within the enforce-buy function whenever a sale is completed and a royalty payment is made to the creator of the token being sold. 
+
+The ROYALTY event is emitted within the enforce-buy function whenever a sale is completed and a royalty payment is made to the creator of the token being sold.
 
 This event is emitted using the following line of code:
 `(emit-event (ROYALTY sale-id (at 'id token) royalty-payout creator))`
-

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -67,6 +67,7 @@
 
 (begin-tx)
   (use marmalade-v2.ledger)
+  (use marmalade-v2.guard-policy-v1)
   (use marmalade-v2.util-v1)
   (use mini-guard-utils)
 
@@ -94,6 +95,15 @@
   (expect "mint a default token with quote-policy, non-fungible-policy"
     true
     (mint (read-msg 'token-id )  (read-msg 'account ) (read-keyset 'account-guard ) 1.0))
+
+  (expect "create-token and mint events"
+     [{"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" {"creator": "k:creator","creator-guard": (at 'creator-guard (read-msg 'royalty_spec)),"fungible": coin,"royalty-rate": 0.05}]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.guard-policy-v1] "test-royalty-uri" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.ledger.MINT","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
 (commit-tx)
 
 (begin-tx "Create token - test guards")
@@ -116,7 +126,6 @@
   (expect-failure "Creator guard does not match creator"
     "Creator guard does not match"
     (create-token (read-msg 'token-id) 0 "test2-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
-
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
@@ -218,23 +227,24 @@
     "(enforce (= fungible (at 'fung...: Failure: Tx Failed: Offer is restricted to sale using fungible: coin"
     (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
 
-  (env-data {
-    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
-    ,"quote":{
-       "spec": {
-         "fungible": coin
-         ,"price": 2.0
-         ,"amount": 1.0
-         ,"seller-fungible-account": {
-             "account": "k:account"
-            ,"guard": {"keys": ["account"], "pred": "keys-all"}
-           }
-       }
-       ,"seller-guard": {"keys": ["account"], "pred": "keys-all"}
-       ,"quote-guards": []
-     }
-  })
 (rollback-tx)
+
+(begin-tx "Fund buyer fungible account")
+
+  (env-data {
+    "buyer": "k:buyer"
+   ,"buyer_fungible_account": "k:buyer"
+   ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
+   })
+
+  (test-capability (coin.COINBASE))
+  (coin.coinbase "k:buyer" (read-keyset 'buyer-guard) 2.0)
+
+  (expect "coinbase events"
+   [{"name": "coin.TRANSFER","params": ["" "k:buyer" 2.0]}]
+   (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
 
 (begin-tx)
 
@@ -285,9 +295,6 @@
    ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
    })
 
-  (test-capability (coin.COINBASE))
-  (coin.coinbase "k:buyer" (read-keyset 'buyer-guard) 2.0)
-
   (env-sigs
    [{'key:'buyer
     ,'caps: [
@@ -317,8 +324,25 @@
     "Expect creator balance to be correct"
     0.1 (coin.get-balance "k:creator"))
 
-
   (env-data {
-    "buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}})
+    "seller-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}})
+
+  (expect "sale events"
+   [{"name": "marmalade-v2.quote-manager.QUOTE","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" {"amount": 1.0,"fungible": coin,"price": 2.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'seller-guard)}}]}
+    {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" (read-keyset 'seller-guard) []]}
+    {"name": "marmalade-v2.ledger.OFFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" 1.0 1690025195]}
+    {"name": "marmalade-v2.ledger.SALE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" 1.0 1690025195 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
+    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" (account-guard "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg")]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 1.0,"previous": 0.0}]}
+    {"name": "coin.TRANSFER","params": ["k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0]}
+    {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 0.1 "k:creator"]}
+    {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" "k:creator" 0.1]}
+    {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" "k:account" 1.9]}
+    {"name": "marmalade-v2.ledger.BUY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" "k:buyer" 1.0 1690025195 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
+    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" (read-keyset 'buyer-guard)]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" "k:buyer" 1.0]} {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+  (map (remove "module-hash")  (env-events true)))
 
 (commit-tx)

--- a/pact/policy-manager/policy-manager.md
+++ b/pact/policy-manager/policy-manager.md
@@ -13,6 +13,25 @@ This module includes the following key components:
 
 **Concrete Policies Schema:**: The `concrete-policies` schema contains the module reference. We strictly limit the module to use the interface, `token-policy-v2`
 
+**Capabilities**
+ - `GOVERNANCE`
+ - `CONCRETE-POLICY` @event
+ - `ESCROW`
+ - `MAP-ESCROWED-BUY`
+ - `OFFER`
+ - `BUY`
+ - `WITHDRAW`
+ - `RESERVE-SALE-AT-PRICE` @event
+ - `INIT-CALL`
+ - `TRANSFER-CALL`
+ - `MINT-CALL`
+ - `BURN-CALL`
+ - `OFFER-CALL`
+ - `WITHDRAW-CALL`
+ - `BUY-CALL`
+ - `ADD-QUOTE-CALL`
+ - `UPDATE-QUOTE-PRICE-CALL`
+
 ## Policy Functions
 
 `enforce-**` functions requires the `ledger::**-CALL` capability to be in scope, which enforces that the function is started from the ledger with the scoped parameters. It then retrieves the `policies` list from the `token` input parameter, which contains a list of policies associated with the token.
@@ -33,7 +52,7 @@ This module includes the following key components:
 
 `reserve-sale-at-price`: Updates the quote price and reserves the sale, and the marmalade buyer account information. Fungible payment is required. After this step, anyone can process `marmalade-v2.ledger.buy` step.
   - Required Capability
-    - Capability: `(RESERVE_SALE_AT_PRICE sale-id price buyer buyer-guard)`
+    - Capability: `(RESERVE-SALE-AT-PRICE sale-id price buyer buyer-guard)`
     - Signer: One of the `quote-guards`
     - Capability: `(fungible::TRANSFER buyer-fungible-account escrow-account sale-price)`
     - Signer: buyer-fungible-account
@@ -44,10 +63,9 @@ This module includes the following key components:
 
 `write-concrete-policy`: Registers concrete policy modref into the concrete-policies table.
   - Required Capability
-    - Capability: `(CONCRETE_POLICY policy-field policy)`
+    - Capability: `(CONCRETE-POLICY policy-field policy)`
     - Signer: (keyset-ref-guard `marmalade-v2.marmalade-admin`)
 
 `get-concrete-policy`: Returns the modref of the concrete policy.
-
 
 `enforce-sale-pact`: Ensures that the `sale` parameter provided to the function is equal to the ID of the currently executing pact. It does this by calling the `pact-id` function to retrieve the ID of the currently executing pact and comparing it to the provided `sale` parameter. If they are not equal, an exception will be thrown".

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -18,17 +18,12 @@
   (defconst BUYER-FUNGIBLE-ACCOUNT-MSG-KEY "buyer_fungible_account"
     @doc "Payload field for buyer's fungible account")
 
-  (defcap POLICY_MANAGER:bool ()
-    @doc "Ledger module guard for policies to be able to validate access to policy operations."
-    true
-  )
-
   (defcap ESCROW (sale-id:string)
     @doc "Capability to be used as escrow's capability guard"
     true
   )
 
-  (defcap MAP_ESCROWED_BUY:bool (
+  (defcap MAP-ESCROWED-BUY:bool (
     sale-id:string
     token:object{token-info}
     seller:string
@@ -114,7 +109,7 @@
     policy:module{kip.token-policy-v2}
   )
 
-  (defcap CONCRETE_POLICY:bool (policy-field:string policy:module{kip.token-policy-v2})
+  (defcap CONCRETE-POLICY:bool (policy-field:string policy:module{kip.token-policy-v2})
     @event
     (enforce-guard "marmalade-v2.marmalade-admin")
   )
@@ -130,7 +125,7 @@
 
   (defun write-concrete-policy:bool (policy-field:string policy:module{kip.token-policy-v2})
     (contains policy-field CONCRETE_POLICY_LIST)
-    (with-capability (CONCRETE_POLICY policy-field policy)
+    (with-capability (CONCRETE-POLICY policy-field policy)
       (write concrete-policies policy-field {
         "policy": policy
         }
@@ -313,7 +308,7 @@
 
           ; Checks if price is final
           (enforce (> price 0.0) "Price must be finalized before buy")
-          (with-capability (MAP_ESCROWED_BUY sale-id token seller buyer buyer-guard amount timeout (at 'policies token))
+          (with-capability (MAP-ESCROWED-BUY sale-id token seller buyer buyer-guard amount timeout (at 'policies token))
             (map-escrowed-buy sale-id token seller buyer buyer-guard amount timeout (at 'policies token))
           )
         )
@@ -344,7 +339,7 @@
   )
 
   ; Sale/Escrow Functions
-  (defcap RESERVE_SALE_AT_PRICE:bool
+  (defcap RESERVE-SALE-AT-PRICE:bool
     ( sale-id:string
       price:decimal
       buyer:string
@@ -372,8 +367,8 @@
     (enforce-reserved buyer buyer-guard)
 
     (with-capability (UPDATE-QUOTE-PRICE-CALL sale-id price buyer)
-      (with-capability (RESERVE_SALE_AT_PRICE sale-id price buyer buyer-guard)
-        (install-capability (UPDATE_QUOTE_PRICE sale-id price buyer))
+      (with-capability (RESERVE-SALE-AT-PRICE sale-id price buyer buyer-guard)
+        (install-capability (UPDATE-QUOTE-PRICE sale-id price buyer))
         (update-quote-price sale-id price buyer)
       )
     )
@@ -403,7 +398,7 @@
       timeout:integer
       policies:[module{kip.token-policy-v2}]
     )
-    (require-capability (MAP_ESCROWED_BUY sale-id token seller buyer buyer-guard amount timeout policies))
+    (require-capability (MAP-ESCROWED-BUY sale-id token seller buyer buyer-guard amount timeout policies))
     (let* (
            (escrow-account:object{fungible-account} (get-escrow-account sale-id))
            (quote:object{quote-schema} (get-quote-info sale-id))

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -417,7 +417,7 @@
 
   (expect "offer events"
       [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
-        {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
+        {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
         {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0]}
         {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0 (pact-id)]}
         {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
@@ -512,7 +512,7 @@
 
   (expect "offer events"
       [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
-        {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
+        {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote )) []]}
         {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0]}
         {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0 (pact-id)]}
         {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
@@ -611,7 +611,7 @@
 
 (expect "offer events"
     [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
-      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote ))  (at 'quote-guards (read-msg 'quote ))]}
+      {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote ))  (at 'quote-guards (read-msg 'quote ))]}
       {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 0]}
       {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 0 (pact-id)]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
@@ -629,7 +629,7 @@
    (env-sigs [
       { 'key: 'market
       ,'caps: [
-          (marmalade-v2.policy-manager.RESERVE_SALE_AT_PRICE (pact-id) 1.0 (read-msg 'buyer) (read-keyset 'buyer-guard))
+          (marmalade-v2.policy-manager.RESERVE-SALE-AT-PRICE (pact-id) 1.0 (read-msg 'buyer) (read-keyset 'buyer-guard))
         ]}
       { 'key: 'market-fungible
       ,'caps: [
@@ -677,7 +677,7 @@
     (continue-pact 1))
 
   (expect "buy events"
-    [ {"name": "marmalade-v2.policy-manager.RESERVE_SALE_AT_PRICE","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer" (read-keyset 'buyer-guard)]}
+    [ {"name": "marmalade-v2.policy-manager.RESERVE-SALE-AT-PRICE","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["k:market-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.0]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 1.0]}
       {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
@@ -686,5 +686,4 @@
       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
     (map (remove "module-hash")  (env-events true))
   )
-
 (rollback-tx)

--- a/pact/quote-manager/quote-manager.md
+++ b/pact/quote-manager/quote-manager.md
@@ -12,6 +12,13 @@ This module includes the following key components:
 
 **QUOTE-SPEC SCHEMA**: The `quote-spec` schema contains fungible information about the sale, and is part of `quote` schema. It consists of `fungible`, `seller-account`, `price`, `amount`.
 
+**Capabilities**
+  - `GOVERNANCE`
+  - `UPDATE-QUOTE-GUARD`
+  - `UPDATE-QUOTE-PRICE`
+  - `QUOTE` @event
+  - `QUOTE-GUARDS` @event
+
 ## Quote Manager Functions
 
 Main functions of quote manager includes

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -73,16 +73,8 @@
     true
   )
 
-  (defcap QUOTE_PRICE_UPDATE:bool
-    ( sale-id:string
-      price:decimal
-      buyer:string
-    )
-    @event
-    true
-  )
 
-  (defcap QUOTE_GUARDS:bool
+  (defcap QUOTE-GUARDS:bool
     ( sale-id:string
       token-id:string
       seller-guard:guard
@@ -94,7 +86,7 @@
 
   (deftable quotes:{quote-schema})
 
-  (defcap UPDATE_QUOTE_PRICE:bool (sale-id:string price:decimal buyer:string)
+  (defcap UPDATE-QUOTE-PRICE:bool (sale-id:string price:decimal buyer:string)
     @doc "Enforces quote-guards on update-quote-price"
     (with-read quotes sale-id {
       "quote-guards":=quote-guards
@@ -104,7 +96,7 @@
     true
   )
 
-  (defcap UPDATE_QUOTE_GUARD:bool (sale-id:string)
+  (defcap UPDATE-QUOTE-GUARD:bool (sale-id:string)
     @doc "Enforces seller-guard on update-quote-guard"
     (with-read quotes sale-id {
       "seller-guard":= guard
@@ -117,7 +109,7 @@
 ;; Quote storage functions
   (defun remove-quote-guard:bool (sale-id:string guard:guard)
     @doc "Removes a quote-guard if signed by the seller guard"
-    (with-capability (UPDATE_QUOTE_GUARD sale-id)
+    (with-capability (UPDATE-QUOTE-GUARD sale-id)
       (with-read quotes sale-id {
           "token-id":=token-id
          ,"seller-guard":= seller-guard
@@ -128,12 +120,12 @@
           (update quotes sale-id {
             "quote-guards": updated-guards
           })
-        (emit-event (QUOTE_GUARDS sale-id token-id seller-guard updated-guards)))))
+        (emit-event (QUOTE-GUARDS sale-id token-id seller-guard updated-guards)))))
   )
 
   (defun add-quote-guard:bool (sale-id:string guard:guard)
     @doc "Adds a quote-guard if signed by the seller guard"
-    (with-capability (UPDATE_QUOTE_GUARD sale-id)
+    (with-capability (UPDATE-QUOTE-GUARD sale-id)
       (with-read quotes sale-id {
           "token-id":=token-id
          ,"seller-guard":= seller-guard
@@ -144,7 +136,7 @@
           (update quotes sale-id {
             "quote-guards": updated-guards
           })
-        (emit-event (QUOTE_GUARDS sale-id token-id seller-guard updated-guards)))))
+        (emit-event (QUOTE-GUARDS sale-id token-id seller-guard updated-guards)))))
   )
 
   (defun add-quote:bool (sale-id:string token-id:string quote-msg:object{quote-msg})
@@ -163,7 +155,7 @@
          , "reserved": ""
         })
         (emit-event (QUOTE sale-id token-id quote-spec))
-        (emit-event (QUOTE_GUARDS sale-id token-id seller-guard quote-guards))
+        (emit-event (QUOTE-GUARDS sale-id token-id seller-guard quote-guards))
        true
     )
   )
@@ -173,7 +165,7 @@
     (let ((policy-manager:module{policy-manager-v1} (retrieve-policy-manager)))
       (require-capability (policy-manager::UPDATE-QUOTE-PRICE-CALL sale-id price buyer))
     )
-    (with-capability (UPDATE_QUOTE_PRICE sale-id price buyer)
+    (with-capability (UPDATE-QUOTE-PRICE sale-id price buyer)
       (with-read quotes sale-id {
           "spec":= quote-spec
         }

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -63,7 +63,8 @@
        (mint (read-msg 'token-id) "k:account" (read-keyset 'account-guard ) 1.0))
 
      (expect "create, mint token events"
-        [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" 0 [marmalade-v2.royalty-policy-v1] "test-quote-royalty-uri" ALWAYS-TRUE]}
+        [ {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" {"creator": "k:creator","creator-guard": (at 'creator-guard (read-msg 'royalty_spec)),"fungible": coin,"royalty-rate": 0.05}]}
+          {"name": "marmalade-v2.ledger.TOKEN","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" 0 [marmalade-v2.royalty-policy-v1] "test-quote-royalty-uri" ALWAYS-TRUE]}
           {"name": "marmalade-v2.ledger.MINT","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" 1.0]}
           {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" (read-keyset 'account-guard)]}
           {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" 1.0]}
@@ -113,7 +114,7 @@
 
   (expect "Offer with quote events"
     [ {"name": "marmalade-v2.quote-manager.QUOTE","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" {"amount": 1.0,"fungible": coin,"price": 10.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'account-guard )}}]}
-      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) [(read-keyset 'market-guard)]]}
+      {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) [(read-keyset 'market-guard)]]}
       {"name": "marmalade-v2.ledger.OFFER","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" 1.0 0]}
       {"name": "marmalade-v2.ledger.SALE","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" 1.0 0 "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo" (account-guard (read-string "token-id") "c:s0U-eAHPqrKNfJElCDaypSWOOryXXOqwwWV2FA8usNo")]}
@@ -132,7 +133,7 @@
 
   (env-sigs [
     { 'key: 'any
-    ,'caps: [(marmalade-v2.quote-manager.UPDATE_QUOTE_GUARD "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o")]}
+    ,'caps: [(marmalade-v2.quote-manager.UPDATE-QUOTE-GUARD "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o")]}
     ])
 
   (expect-failure "remove quote guard fails without seller sig"
@@ -141,7 +142,7 @@
 
   (env-sigs [
     { 'key: 'account
-    ,'caps: [(marmalade-v2.quote-manager.UPDATE_QUOTE_GUARD "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o")]}
+    ,'caps: [(marmalade-v2.quote-manager.UPDATE-QUOTE-GUARD "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o")]}
     ])
 
   (expect "seller can remove quote guard"
@@ -158,7 +159,7 @@
     (env-sigs [
       { 'key: 'market
       ,'caps: [
-          (marmalade-v2.policy-manager.RESERVE_SALE_AT_PRICE (read-msg 'sale-id) 20.0 (read-msg 'buyer) (read-keyset 'buyer-guard))
+          (marmalade-v2.policy-manager.RESERVE-SALE-AT-PRICE (read-msg 'sale-id) 20.0 (read-msg 'buyer) (read-keyset 'buyer-guard))
         ]}
       ])
 
@@ -173,7 +174,7 @@
 
   (env-sigs [
     { 'key: 'any
-    ,'caps: [(marmalade-v2.quote-manager.UPDATE_QUOTE_GUARD "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o")]}
+    ,'caps: [(marmalade-v2.quote-manager.UPDATE-QUOTE-GUARD "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o")]}
     ])
 
   (env-data {
@@ -187,7 +188,7 @@
 
  (env-sigs [
    { 'key: 'account
-   ,'caps: [(marmalade-v2.quote-manager.UPDATE_QUOTE_GUARD "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o")]}
+   ,'caps: [(marmalade-v2.quote-manager.UPDATE-QUOTE-GUARD "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o")]}
    ])
 
   (expect "seller can add quote guard"
@@ -195,8 +196,8 @@
     (marmalade-v2.quote-manager.add-quote-guard  "4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" (read-keyset 'market-guard) ))
 
   (expect "Quote guard Events"
-    [ {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) []]}
-      {"name": "marmalade-v2.quote-manager.QUOTE_GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) [ (read-keyset 'market-guard) ]]}]
+    [ {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) []]}
+      {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": ["4OsyAnzjiE0phoCAJ3tZ_bRR2OH3TXk7gP5Cobq4E8o" "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" (read-keyset 'account-guard) [ (read-keyset 'market-guard) ]]}]
      (map (remove "module-hash")  (env-events true))
   )
 
@@ -223,7 +224,7 @@
       ]}
       { 'key: 'market
       ,'caps: [
-          (marmalade-v2.policy-manager.RESERVE_SALE_AT_PRICE (read-msg 'sale-id) 20.0 (read-msg 'buyer) (read-keyset 'buyer-guard))
+          (marmalade-v2.policy-manager.RESERVE-SALE-AT-PRICE (read-msg 'sale-id) 20.0 (read-msg 'buyer) (read-keyset 'buyer-guard))
         ]}
     ])
 


### PR DESCRIPTION
- Change capability namings to use `-` instead of `_`

Collecton Policy 
- Removed `OPERATOR` cap, replaced with `TOKEN_COLLECTION`  to check operator guard 
- re-ordered arguements in `TOKEN_COLLECTION` to list `collection-id`, `token-id` from `token-id`, `collection-id`

Guard Policy 
- Added `token-id` at GUARDS cap 

Royalty Policy 
- Changed ROYALTY cap to ROYALTY-PAYOUT cap, and dded ROYALTY cap to emit ROYALTY information at creation 

Policy Mangaer 
 - Removed POLICY_MANAGER cap from old code 

Quote-Manager: 
 - Removed `UPDATED_QUOTE_PRICE` cap. update-quote-price is only to be called within `reserve-sale-at-price`, and RESERVE-SALE-AT-PRICE emits price information. 
 