### PR TITLE
Remove timeout enforcement at `buy` 

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -131,7 +131,6 @@
       buyer:string
       buyer-guard:guard
       amount:decimal
-      timeout:integer
       sale-id:string
     )
     true

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -159,9 +159,8 @@
       buyer:string
       buyer-guard:guard
       amount:decimal
-      timeout:integer
       sale-id:string )
-    (require-capability (BUY-CALL (at "id" token) seller buyer amount sale-id timeout guard-policy-v1))
+    (require-capability (BUY-CALL (at "id" token) seller buyer amount sale-id guard-policy-v1))
     (enforce-sale-pact sale-id)
     (with-capability (SALE (at 'id token) seller amount)
       true

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -54,7 +54,6 @@
       buyer:string
       buyer-guard:guard
       amount:decimal
-      timeout:integer
       sale-id:string )
     true
   )

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -122,9 +122,8 @@
       buyer:string
       buyer-guard:guard
       amount:decimal
-      timeout:integer
       sale-id:string )
-    (require-capability (BUY-CALL (at "id" token) seller buyer amount sale-id timeout royalty-policy-v1))
+    (require-capability (BUY-CALL (at "id" token) seller buyer amount sale-id royalty-policy-v1))
     (enforce-sale-pact sale-id)
     (bind (get-royalty token)
       { 'fungible := fungible:module{fungible-v2}

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -298,7 +298,7 @@
   (env-sigs
    [{'key:'buyer
     ,'caps: [
-      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) "k:account" "k:buyer"  1.0 (to-timestamp (time  "2023-07-22T11:26:35Z")) "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) "k:account" "k:buyer"  1.0 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
       (coin.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
      ]}])
 
@@ -340,7 +340,7 @@
     {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 0.1 "k:creator"]}
     {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" "k:creator" 0.1]}
     {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" "k:account" 1.9]}
-    {"name": "marmalade-v2.ledger.BUY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" "k:buyer" 1.0 1690025195 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
+    {"name": "marmalade-v2.ledger.BUY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" "k:buyer" 1.0 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" (read-keyset 'buyer-guard)]}
     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" "k:buyer" 1.0]} {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
   (map (remove "module-hash")  (env-events true)))

--- a/pact/kip/token-policy-v2.pact
+++ b/pact/kip/token-policy-v2.pact
@@ -54,7 +54,6 @@
       buyer:string
       buyer-guard:guard
       amount:decimal
-      timeout:integer
       sale-id:string )
     @doc "Buy policy on SALE-ID by SELLER to BUYER AMOUNT of TOKEN."
   )

--- a/pact/ledger/ledger.interface.pact
+++ b/pact/ledger/ledger.interface.pact
@@ -32,7 +32,7 @@
       "Capability securing the modref call for enforce-withdraw"
   )
 
-  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal timeout:integer sale-id:string)
+  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal sale-id:string)
     @doc
       "Capability securing the modref call for enforce-buy"
   )

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -138,7 +138,7 @@
     true
   )
 
-  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal timeout:integer sale-id:string)
+  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal sale-id:string)
     true
   )
 
@@ -524,7 +524,7 @@
   )
 
   (defcap BUY:bool
-    (id:string seller:string buyer:string amount:decimal timeout:integer sale-id:string)
+    (id:string seller:string buyer:string amount:decimal sale-id:string)
     @doc "Completes sale OFFER to BUYER."
     @managed
     (compose-capability (SALE_PRIVATE sale-id))
@@ -562,10 +562,10 @@
       ;; Step 1: buy
       (let ( (buyer:string (read-msg "buyer"))
               (buyer-guard:guard (read-msg "buyer-guard")) )
-          (with-capability (BUY-CALL id seller buyer amount timeout (pact-id))
-            (marmalade-v2.policy-manager.enforce-buy (get-token-info id) seller buyer buyer-guard amount timeout (pact-id))
+          (with-capability (BUY-CALL id seller buyer amount (pact-id))
+            (marmalade-v2.policy-manager.enforce-buy (get-token-info id) seller buyer buyer-guard amount (pact-id))
           )
-          (with-capability (BUY id seller buyer amount timeout (pact-id))
+          (with-capability (BUY id seller buyer amount (pact-id))
             (buy id seller buyer buyer-guard amount (pact-id))
           )
           (pact-id)

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -527,7 +527,6 @@
     (id:string seller:string buyer:string amount:decimal timeout:integer sale-id:string)
     @doc "Completes sale OFFER to BUYER."
     @managed
-    (enforce (sale-active timeout) "BUY: expired")
     (compose-capability (SALE_PRIVATE sale-id))
     (compose-capability (DEBIT id (sale-account)))
     (compose-capability (CREDIT id buyer))

--- a/pact/policy-manager/policy-manager.interface.pact
+++ b/pact/policy-manager/policy-manager.interface.pact
@@ -9,6 +9,11 @@
     "Capability securing the modref call for add-quote"
   )
 
+  (defcap CLOSE-QUOTE-CALL:bool (sale-id:string)
+    @doc
+    "Capability securing the modref call for close-quote"
+  )
+
   (defcap UPDATE-QUOTE-PRICE-CALL:bool (sale-id:string price:decimal buyer:string)
     @doc
     "Capability securing the modref call for update-quote-price"

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -268,19 +268,18 @@
       (let* (
         (quote (get-quote-info sale-id)))
         (enforce-quote-active sale-id)
-        (map (lambda (policy:module{kip.token-policy-v2})
-          (with-capability (WITHDRAW-CALL (at "id" token) seller amount sale-id timeout policy)
-            (policy::enforce-withdraw token seller amount timeout sale-id)
-          )
-        ) (at 'policies token))
-
-      )
-      (map (lambda (policy:module{kip.token-policy-v2})
-        (with-capability (WITHDRAW-CALL (at "id" token) seller amount sale-id timeout policy)
-          (policy::enforce-withdraw token seller amount timeout sale-id)
+        (with-capability (CLOSE-QUOTE-CALL sale-id)
+          (close-quote sale-id)
         )
-      ) (at 'policies token))
-    ))
+      )
+      true
+    )
+    (map (lambda (policy:module{kip.token-policy-v2})
+      (with-capability (WITHDRAW-CALL (at "id" token) seller amount sale-id timeout policy)
+        (policy::enforce-withdraw token seller amount timeout sale-id)
+      )
+    ) (at 'policies token))
+  )
 
   (defun enforce-buy:[bool]
     ( token:object{token-info}

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -686,3 +686,117 @@
     (map (remove "module-hash")  (env-events true))
   )
 (rollback-tx)
+
+(begin-tx "Test enforce-offer, enforce-withdraw, reserve-sale-at-price with quote after timeout fails")
+  (env-chain-data {"chain-id": "0",  "block-time": (time "2023-07-01T00:00:00Z")})
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-fungible-account": "k:seller-fungible-account"
+    , "seller-fungible-guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
+    })
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+
+  (env-data {
+      "token-id": "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA"
+     ,"seller": "k:account"
+     ,"quote":{
+        "spec": {
+          "fungible": marmalade-v2.abc
+          ,"price": 2.0
+          ,"amount": 1.0
+          ,"seller-fungible-account": {
+              "account": "k:seller-fungible-account"
+             ,"guard": {"keys": ["seller-fungible-account"], "pred": "keys-all"}
+            }
+        }
+        ,"seller-guard": {"keys": ["account"], "pred": "keys-all"}
+        ,"quote-guards": [{"keys": ["market"], "pred": "keys-all"}]
+      }
+    }
+  )
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-10T00:00:00Z")))]
+    }])
+
+  (expect "start offer with quote spec"
+    (pact-id)
+    (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-10T00:00:00Z"))))
+
+(expect "offer events"
+    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (at 'spec (read-msg 'quote )) ]}
+      {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": [(pact-id) (read-string 'token-id) (at 'seller-guard (read-msg 'quote ))  (at 'quote-guards (read-msg 'quote ))]}
+      {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-10T00:00:00Z"))]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-10T00:00:00Z")) (pact-id)]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) "k:account" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+    ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-data {
+    "buyer": "k:buyer"
+   ,"buyer-guard": {"keys": ['buyer], "pred": "keys-all"}
+   })
+
+   (env-sigs [
+      { 'key: 'market
+      ,'caps: [
+          (marmalade-v2.policy-manager.RESERVE-SALE-AT-PRICE (pact-id) 1.0 (read-msg 'buyer) (read-keyset 'buyer-guard))
+        ]}
+      { 'key: 'market-fungible
+      ,'caps: [
+          (marmalade-v2.abc.TRANSFER "k:market-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.0)
+      ]}
+    ])
+  (env-chain-data {"chain-id": "0",  "block-time": (time "2023-08-01T00:00:00Z")})
+
+  (expect "reserve-sale-at-price succeeds after timeout"
+    true
+    (reserve-sale-at-price (pact-id) 1.0 (read-string 'buyer) (read-keyset 'buyer-guard ) "k:market-fungible"))
+
+  (expect "reserve-sale-at-price events"
+    [ {"name": "marmalade-v2.policy-manager.RESERVE-SALE-AT-PRICE","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer" (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.abc.TRANSFER","params": ["k:market-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.0]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" 1.0 (to-timestamp (time "2023-07-10T00:00:00Z")) (pact-id))]
+    }])
+
+  (expect-failure "Withdraw fails when quote is reserved"
+    "QUOTE: Inactive"
+    (continue-pact 0 true))
+
+  (env-sigs
+    [ {'key:'buyer
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 (pact-id))
+      ]}
+  ])
+
+  (expect "Buy succeeds after timeout"
+    (pact-id)
+    (continue-pact 1))
+
+  (expect "buy events"
+   [ {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 1.0]}
+     {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:buyer" (read-keyset 'buyer-guard)]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(rollback-tx)

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -72,7 +72,6 @@
           buyer:string
           buyer-guard:guard
           amount:decimal
-          timeout:integer
           sale-id:string )
         (require-capability (BUY-CALL (at "id" token) seller buyer amount sale-id))
       )
@@ -244,7 +243,7 @@
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 (pact-id))
       ]}
   ])
 
@@ -257,14 +256,14 @@
 
   (expect-failure "enforce-buy cannot be called directly"
    "(require-capability (ledger::B...: Failure: require-capability: not granted: (marmalade-v2.ledger.BUY-CALL"
-   (enforce-buy (get-token-info (read-string 'token-id )) (read-string 'seller ) (read-string 'buyer ) (read-keyset 'buyer-guard ) 1.0 0 (pact-id)))
+   (enforce-buy (get-token-info (read-string 'token-id )) (read-string 'seller ) (read-string 'buyer ) (read-keyset 'buyer-guard ) 1.0 (pact-id)))
 
   (expect "Buy succeeds"
     (pact-id)
     (continue-pact 1))
 
   (expect "buy events"
-   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:buyer" (read-keyset 'buyer-guard)]}
      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" "k:buyer" 1.0]}
      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
@@ -343,7 +342,7 @@
       ]}
     {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 (pact-id))
       ]}
   ])
 
@@ -451,7 +450,7 @@
       ]}
     {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 (pact-id))
       ]}
   ])
 
@@ -535,7 +534,7 @@
        ]}
      {'key:'buyer
        ,'caps: [
-         (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
+         (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 (pact-id))
        ]}
    ])
 
@@ -546,7 +545,7 @@
   (expect "buy events"
     [ {"name": "marmalade-v2.abc.TRANSFER","params": ["k:buyer-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 2.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
@@ -654,7 +653,7 @@
   (env-sigs
     [ {'key:'buyer
       ,'caps: [
-        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 (pact-id))
+        (marmalade-v2.ledger.BUY "t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 (pact-id))
       ]}
   ])
 
@@ -680,7 +679,7 @@
     [ {"name": "marmalade-v2.policy-manager.RESERVE-SALE-AT-PRICE","params": ["i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY" 1.0 "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["k:market-fungible" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.0]}
       {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" "k:seller-fungible-account" 1.0]}
-      {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:account" "k:buyer" 1.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "k:buyer" (read-keyset 'buyer-guard)]}
       {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" "k:buyer" 1.0]}
       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:RhvmOpBRc0_ZdNttX_D-z2D0-9XRtf3lzN10PhPBGuA" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -648,7 +648,7 @@
     }])
 
   (expect-failure "Withdraw fails when a sale is reserved"
-    "Sale is reserved, unable to withdraw"
+    "QUOTE: Inactive"
     (continue-pact 0 true))
 
   (env-sigs

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -226,21 +226,13 @@
       true)
   )
 
-  (defun quote-active:bool (sale-id:string)
-    (with-read quotes sale-id {
-      "active":= active
-      }
-      active
-    )
-  )
-
   (defun enforce-quote-active:bool (sale-id:string)
     (with-read quotes sale-id {
       "active":= active
       }
       (enforce active "QUOTE: Inactive")
     )
-  ) 
+  )
 
 )
 

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -233,7 +233,6 @@
       (enforce active "QUOTE: Inactive")
     )
   )
-
 )
 
 (if (read-msg 'upgrade )

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -56,6 +56,7 @@
     seller-guard:guard
     quote-guards:[guard]
     reserved:string
+    active:bool
   )
 
   (defschema fungible-account
@@ -153,6 +154,7 @@
          , "quote-guards": quote-guards
          , "spec": quote-spec
          , "reserved": ""
+         , "active": true
         })
         (emit-event (QUOTE sale-id token-id quote-spec))
         (emit-event (QUOTE-GUARDS sale-id token-id seller-guard quote-guards))
@@ -182,8 +184,20 @@
               , "seller-fungible-account": fungible-account
             }
             , "reserved": buyer
+            , "active": false
             }))
       ))
+    true
+  )
+
+  (defun close-quote:bool (sale-id:string)
+    @doc "Closes quote at withdraw or buy"
+    (let ((policy-manager:module{policy-manager-v1} (retrieve-policy-manager)))
+      (require-capability (policy-manager::CLOSE-QUOTE-CALL sale-id))
+    )
+    (update quotes sale-id {
+      "active": false
+    })
     true
   )
 
@@ -211,6 +225,23 @@
       (enforce (>= price 0.0) "Offer price must be positive or zero")
       true)
   )
+
+  (defun quote-active:bool (sale-id:string)
+    (with-read quotes sale-id {
+      "active":= active
+      }
+      active
+    )
+  )
+
+  (defun enforce-quote-active:bool (sale-id:string)
+    (with-read quotes sale-id {
+      "active":= active
+      }
+      (enforce active "QUOTE: Inactive")
+    )
+  ) 
+
 )
 
 (if (read-msg 'upgrade )

--- a/pact/quote-manager/quote-manager.repl
+++ b/pact/quote-manager/quote-manager.repl
@@ -235,7 +235,7 @@
   (env-sigs [
      { 'key: 'any
      ,'caps: [
-         (marmalade-v2.ledger.BUY "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" "k:buyer"  1.0 0 (read-string 'sale-id))
+         (marmalade-v2.ledger.BUY "t:dxhD6igHw2OaaV_fwrFX4nJUrWsslZk6k-LuRFyOGuI" "k:account" "k:buyer"  1.0 (read-string 'sale-id))
        ]
      }
    ])


### PR DESCRIPTION
- Removes `sale-active` enforcement at `ledger.buy`
- Adds `close-quote` function to update quote status at `enforce-withdraw`, `enforce-buy`, and also separately update status to `false` at `update-quote-price`. 
