### PR TITLE
revert back to hard-code keyset string name in governance

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -5,10 +5,8 @@
 
   @doc "Collection token policy."
 
-  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
-
   (defcap GOVERNANCE ()
-    (enforce-guard GOVERNANCE-KS))
+    (enforce-guard "marmalade-v2.marmalade-admin"))
 
   (implements kip.token-policy-v2)
 

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -5,8 +5,10 @@
 
   @doc "Collection token policy."
 
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-admin")
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-guard ADMIN-KS))
 
   (implements kip.token-policy-v2)
 

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -3,8 +3,10 @@
 
 (module guard-policy-v1 GOVERNANCE
 
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-admin")
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-guard ADMIN-KS))
 
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -3,10 +3,8 @@
 
 (module guard-policy-v1 GOVERNANCE
 
-  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
-
   (defcap GOVERNANCE ()
-    (enforce-guard GOVERNANCE-KS))
+    (enforce-guard "marmalade-v2.marmalade-admin"))
 
   (implements kip.token-policy-v2)
   (use kip.token-policy-v2 [token-info])

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -4,8 +4,10 @@
 
   @doc "Concrete policy for issuing an nft with a fixed supply of 1 and precision of 0"
 
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-admin")
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-guard ADMIN-KS))
 
   (implements kip.token-policy-v2)
   (use policy-manager)

--- a/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -4,10 +4,8 @@
 
   @doc "Concrete policy for issuing an nft with a fixed supply of 1 and precision of 0"
 
-  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
-
   (defcap GOVERNANCE ()
-    (enforce-guard GOVERNANCE-KS))
+    (enforce-guard "marmalade-v2.marmalade-admin"))
 
   (implements kip.token-policy-v2)
   (use policy-manager)

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -4,8 +4,10 @@
 
   @doc "Concrete policy to support royalty payouts in a specified fungible during sale."
 
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-admin")
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-guard ADMIN-KS))
 
   (use policy-manager)
   (use policy-manager [QUOTE-MSG-KEY])

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -4,10 +4,8 @@
 
   @doc "Concrete policy to support royalty payouts in a specified fungible during sale."
 
-  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
-
   (defcap GOVERNANCE ()
-    (enforce-guard GOVERNANCE-KS))
+    (enforce-guard "marmalade-v2.marmalade-admin"))
 
   (use policy-manager)
   (use policy-manager [QUOTE-MSG-KEY])

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -40,10 +40,8 @@
   ;; Capabilities
   ;;
 
-  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
-
   (defcap GOVERNANCE ()
-    (enforce-guard GOVERNANCE-KS))
+    (enforce-guard "marmalade-v2.marmalade-admin"))
 
   ;;
   ;; poly-fungible-v3 caps

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -40,9 +40,11 @@
   ;; Capabilities
   ;;
 
-  (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-admin")
 
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+    
   ;;
   ;; poly-fungible-v3 caps
   ;;

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -5,8 +5,10 @@
   (use policy-manager)
   (use policy-manager [CONCRETE_POLICY_LIST NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
 
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-admin")
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-guard ADMIN-KS))
 
   (defschema concrete-policy-bool
     non-fungible-policy:bool

--- a/pact/marmalade-util/util-v1.pact
+++ b/pact/marmalade-util/util-v1.pact
@@ -5,17 +5,15 @@
   (use policy-manager)
   (use policy-manager [CONCRETE_POLICY_LIST NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
 
+  (defcap GOVERNANCE ()
+    (enforce-guard "marmalade-v2.marmalade-admin"))
+
   (defschema concrete-policy-bool
     non-fungible-policy:bool
     royalty-policy:bool
     collection-policy:bool
     guard-policy:bool
   )
-
-  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
-
-  (defcap GOVERNANCE ()
-    (enforce-guard GOVERNANCE-KS))
 
   (defconst DEFAULT:object{concrete-policy-bool}
     { 'non-fungible-policy: true

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -2,10 +2,8 @@
 
 (module policy-manager GOVERNANCE
 
-  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
-
   (defcap GOVERNANCE ()
-    (enforce-guard GOVERNANCE-KS))
+    (enforce-guard "marmalade-v2.marmalade-admin"))
 
   (implements policy-manager-v1)
   (use kip.token-policy-v2 [token-info])

--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -2,8 +2,10 @@
 
 (module policy-manager GOVERNANCE
 
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-admin")
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-guard ADMIN-KS))
 
   (implements policy-manager-v1)
   (use kip.token-policy-v2 [token-info])
@@ -114,7 +116,7 @@
 
   (defcap CONCRETE-POLICY:bool (policy-field:string policy:module{kip.token-policy-v2})
     @event
-    (enforce-guard GOVERNANCE-KS))
+    (enforce-guard ADMIN-KS))
 
   (deftable concrete-policies:{concrete-policy})
 

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -7,10 +7,8 @@
   (use kip.token-policy-v2 [token-info])
   (use util.guards1)
 
-  (defconst GOVERNANCE-KS:string (+ (read-string 'ns) ".marmalade-admin"))
-
   (defcap GOVERNANCE ()
-    (enforce-guard GOVERNANCE-KS))
+    (enforce-guard "marmalade-v2.marmalade-admin"))
 
   ; Saves reference to policy-manager
   (defschema policy-manager

--- a/pact/quote-manager/quote-manager.pact
+++ b/pact/quote-manager/quote-manager.pact
@@ -7,8 +7,10 @@
   (use kip.token-policy-v2 [token-info])
   (use util.guards1)
 
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-admin")
+
   (defcap GOVERNANCE ()
-    (enforce-guard "marmalade-v2.marmalade-admin"))
+    (enforce-guard ADMIN-KS))
 
   ; Saves reference to policy-manager
   (defschema policy-manager


### PR DESCRIPTION
Hard-code "marmalade-v2.marmalade-admin" keyset inside governance.