### PR TITLE
[Royalty policy] Install TRANSFER cap with sale-price in royalty payout

### DIFF
--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -140,7 +140,7 @@
         (if
           (> royalty-payout 0.0)
           (let ((_ ""))
-            (install-capability (fungible::TRANSFER escrow-account creator royalty-payout))
+            (install-capability (fungible::TRANSFER escrow-account creator sale-price))
             (emit-event (ROYALTY-PAYOUT sale-id (at 'id token) royalty-payout creator))
             (fungible::transfer escrow-account creator royalty-payout))
           "No royalty"

--- a/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -26,8 +26,8 @@
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
-   ,"account": "account"
-   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,"account": "k:creator"
+   ,"account-guard": {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty_spec": {
       "fungible": marmalade-v2.abc
      ,"creator": "k:creator"
@@ -50,8 +50,8 @@
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
-   ,"account": "account"
-   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,"account": "k:creator"
+   ,"account-guard": {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty_spec": {
       "fungible": coin
      ,"creator": "k:creator"
@@ -73,8 +73,8 @@
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
-   ,"account": "k:account"
-   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,"account": "k:creator"
+   ,"account-guard": {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty_spec": {
       "fungible": coin
      ,"creator": "k:creator"
@@ -88,8 +88,8 @@
     (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
 
   (env-sigs [
-    { 'key: 'account
-    ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) "k:account" 1.0)]
+    { 'key: 'creator
+    ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) "k:creator" 1.0)]
     }])
 
   (expect "mint a default token with quote-policy, non-fungible-policy"
@@ -100,9 +100,9 @@
      [{"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" {"creator": "k:creator","creator-guard": (at 'creator-guard (read-msg 'royalty_spec)),"fungible": coin,"royalty-rate": 0.05}]}
       {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS}]}
       {"name": "marmalade-v2.ledger.TOKEN","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.guard-policy-v1] "test-royalty-uri" ALWAYS-TRUE]}
-      {"name": "marmalade-v2.ledger.MINT","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" 1.0]}
-      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" (read-keyset 'account-guard)]}
-      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:account","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0]}]
+      {"name": "marmalade-v2.ledger.MINT","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:creator" 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:creator" (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account":"", "current": 0.0,"previous": 0.0} {"account": "k:creator","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0]}]
     (map (remove "module-hash")  (env-events true)))
 (commit-tx)
 
@@ -113,8 +113,8 @@
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
-   ,"account": "k:account"
-   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,"account": "k:creator"
+   ,"account-guard": {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty_spec": {
       "fungible": coin
      ,"creator": "k:badactor"
@@ -129,8 +129,8 @@
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
-   ,"account": "k:account"
-   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,"account": "k:creator"
+   ,"account-guard": {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty_spec": {
       "fungible": marmalade-v2.def
      ,"creator": "k:creator"
@@ -152,8 +152,8 @@
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test3-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
-   ,"account": "k:account"
-   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,"account": "k:creator"
+   ,"account-guard": {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty_spec": {
       "fungible": coin
      ,"creator": "k:creator"
@@ -169,8 +169,8 @@
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test3-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
-   ,"account": "k:account"
-   ,"account-guard": {"keys": ["account"], "pred": "keys-all"}
+   ,"account": "k:creator"
+   ,"account-guard": {"keys": ["creator"], "pred": "keys-all"}
    ,"royalty_spec": {
       "fungible": coin
      ,"creator": "k:creator"
@@ -193,11 +193,10 @@
   (use mini-guard-utils)
 
   (env-data {
-    "seller-guard": {"keys": ["account"], "pred": "keys-all"}
+    "seller-guard": {"keys": ["creator"], "pred": "keys-all"}
   })
 
-  (coin.create-account "k:account" (read-keyset 'seller-guard))
-  (marmalade-v2.def.create-account "k:account" (read-keyset 'seller-guard))
+  (marmalade-v2.def.create-account "k:creator" (read-keyset 'seller-guard))
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
@@ -207,25 +206,25 @@
          ,"price": 2.0
          ,"amount": 1.0
          ,"seller-fungible-account": {
-             "account": "k:account"
-            ,"guard": {"keys": ["account"], "pred": "keys-all"}
+             "account": "k:creator"
+            ,"guard": {"keys": ["creator"], "pred": "keys-all"}
            }
        }
-       ,"seller-guard": {"keys": ["account"], "pred": "keys-all"}
+       ,"seller-guard": {"keys": ["creator"], "pred": "keys-all"}
        ,"quote-guards": []
      }
     })
 
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
   (env-sigs [
-    { 'key: 'account
+    { 'key: 'creator
      ,'caps: [
-     (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
+     (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:creator" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
      }])
 
   (expect-failure "Offer fails when quote uses a different fungible from registered fungible"
     "(enforce (= fungible (at 'fung...: Failure: Tx Failed: Offer is restricted to sale using fungible: coin"
-    (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
+    (sale (read-msg 'token-id) "k:creator" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
 
 (rollback-tx)
 
@@ -235,13 +234,16 @@
     "buyer": "k:buyer"
    ,"buyer_fungible_account": "k:buyer"
    ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}
+   ,"buyer-guard-1": {"keys": ["buyer1"], "pred": "keys-all"}
    })
 
   (test-capability (coin.COINBASE))
   (coin.coinbase "k:buyer" (read-keyset 'buyer-guard) 2.0)
+  (coin.coinbase "k:buyer1" (read-keyset 'buyer-guard-1) 2.0)
 
   (expect "coinbase events"
-   [{"name": "coin.TRANSFER","params": ["" "k:buyer" 2.0]}]
+   [{"name": "coin.TRANSFER","params": ["" "k:buyer" 2.0]}
+    {"name": "coin.TRANSFER","params": ["" "k:buyer1" 2.0]}]
    (map (remove "module-hash")  (env-events true)))
 
 (commit-tx)
@@ -254,10 +256,8 @@
   (use mini-guard-utils)
 
   (env-data {
-    "seller-guard": {"keys": ["account"], "pred": "keys-all"}
+    "seller-guard": {"keys": ["creator"], "pred": "keys-all"}
   })
-
-  (coin.create-account "k:account" (read-keyset 'seller-guard))
 
   (env-data {
     "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
@@ -267,25 +267,35 @@
          ,"price": 2.0
          ,"amount": 1.0
          ,"seller-fungible-account": {
-             "account": "k:account"
-            ,"guard": {"keys": ["account"], "pred": "keys-all"}
+             "account": "k:creator"
+            ,"guard": {"keys": ["creator"], "pred": "keys-all"}
            }
        }
-       ,"seller-guard": {"keys": ["account"], "pred": "keys-all"}
+       ,"seller-guard": {"keys": ["creator"], "pred": "keys-all"}
        ,"quote-guards": []
      }
     })
 
   (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
   (env-sigs [
-    { 'key: 'account
+    { 'key: 'creator
      ,'caps: [
-     (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
+     (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:creator" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
      }])
 
   (expect "start offer by running step 0 of sale"
     "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"
-    (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
+    (sale (read-msg 'token-id) "k:creator" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
+
+  (expect "offer events"
+   [ {"name": "marmalade-v2.quote-manager.QUOTE","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" {"amount": 1.0,"fungible": coin,"price": 2.0,"seller-fungible-account": {"account": "k:creator","guard": (at 'seller-guard (read-msg 'quote))}}]}
+     {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" (at 'seller-guard (read-msg 'quote)) []]}
+     {"name": "marmalade-v2.ledger.OFFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:creator" 1.0 1690025195]}
+     {"name": "marmalade-v2.ledger.SALE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:creator" 1.0 1690025195 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" (account-guard "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg")]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:creator" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "k:creator","current": 0.0,"previous": 1.0} {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 1.0,"previous": 0.0}]}]
+   (map (remove "module-hash")  (env-events true)))
 
   (env-data { "recipient-guard": {"keys": ["seller"], "pred": "keys-all"}})
 
@@ -298,7 +308,7 @@
   (env-sigs
    [{'key:'buyer
     ,'caps: [
-      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) "k:account" "k:buyer"  1.0 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) "k:creator" "k:buyer"  1.0 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
       (coin.TRANSFER "k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
      ]}])
 
@@ -322,27 +332,184 @@
 
   (expect
     "Expect creator balance to be correct"
-    0.1 (coin.get-balance "k:creator"))
+    2.0 (coin.get-balance "k:creator"))
 
   (env-data {
-    "seller-guard": {"keys": ["account"], "pred": "keys-all"}
+    "seller-guard": {"keys": ["creator"], "pred": "keys-all"}
    ,"buyer-guard": {"keys": ["buyer"], "pred": "keys-all"}})
 
-  (expect "sale events"
-   [{"name": "marmalade-v2.quote-manager.QUOTE","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" {"amount": 1.0,"fungible": coin,"price": 2.0,"seller-fungible-account": {"account": "k:account","guard": (read-keyset 'seller-guard)}}]}
-    {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" (read-keyset 'seller-guard) []]}
-    {"name": "marmalade-v2.ledger.OFFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" 1.0 1690025195]}
-    {"name": "marmalade-v2.ledger.SALE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" 1.0 1690025195 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
-    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" (account-guard "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg")]}
-    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" 1.0]}
-    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "k:account","current": 0.0,"previous": 1.0} {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 1.0,"previous": 0.0}]}
-    {"name": "coin.TRANSFER","params": ["k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0]}
-    {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 0.1 "k:creator"]}
-    {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" "k:creator" 0.1]}
-    {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" "k:account" 1.9]}
-    {"name": "marmalade-v2.ledger.BUY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:account" "k:buyer" 1.0 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
-    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" (read-keyset 'buyer-guard)]}
-    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" "k:buyer" 1.0]} {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
-  (map (remove "module-hash")  (env-events true)))
+(expect "buy events"
+  [{"name": "coin.TRANSFER","params": ["k:buyer" "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0]}
+   {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 0.1 "k:creator"]}
+   {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" "k:creator" 0.1]}
+   {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" "k:creator" 1.9]}
+   {"name": "marmalade-v2.ledger.BUY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:creator" "k:buyer" 1.0 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
+   {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" (read-keyset 'buyer-guard)]}
+   {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" "k:buyer" 1.0]}
+   {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 0.0,"previous": 1.0} {"account": "k:buyer","current": 1.0,"previous": 0.0}]}]
+ (map (remove "module-hash")  (env-events true)))
 
 (commit-tx)
+
+(begin-tx)
+
+  (env-hash (hash "offer-royalty-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "seller-guard": {"keys": ["buyer"], "pred": "keys-all"}
+  })
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+    ,"quote":{
+       "spec": {
+         "fungible": coin
+         ,"price": 2.0
+         ,"amount": 1.0
+         ,"seller-fungible-account": {
+             "account": "k:buyer"
+            ,"guard": {"keys": ["buyer"], "pred": "keys-all"}
+           }
+       }
+       ,"seller-guard": {"keys": ["buyer"], "pred": "keys-all"}
+       ,"quote-guards": []
+     }
+    })
+
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+  (env-sigs [
+    { 'key: 'buyer
+     ,'caps: [
+     (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:buyer" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
+     }])
+
+  (expect "start offer by running step 0 of sale"
+    "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"
+    (sale (read-msg 'token-id) "k:buyer" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
+
+  (expect "offer events"
+    [ {"name": "marmalade-v2.quote-manager.QUOTE","params": ["2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" {"amount": 1.0,"fungible": coin,"price": 2.0,"seller-fungible-account": {"account": "k:buyer","guard": (at 'seller-guard (read-msg 'quote))}}]}
+      {"name": "marmalade-v2.quote-manager.QUOTE-GUARDS","params": ["2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" (at 'seller-guard (read-msg 'quote)) []]}
+      {"name": "marmalade-v2.ledger.OFFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" 1.0 1690025195]}
+      {"name": "marmalade-v2.ledger.SALE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" 1.0 1690025195 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI" (account-guard "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "k:buyer","current": 0.0,"previous": 1.0} {"account": "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI","current": 1.0,"previous": 0.0}]}]
+     (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "buyer sells token to buyer1")
+  (env-hash (hash "offer-royalty-1-buy"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "buyer": "k:buyer1"
+   ,"buyer_fungible_account": "k:buyer1"
+   ,"buyer-guard": {"keys": ["buyer1"], "pred": "keys-all"}
+   })
+
+  (env-sigs
+   [{'key:'buyer1
+    ,'caps: [
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) "k:buyer" "k:buyer1"  1.0 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU")
+      (coin.TRANSFER "k:buyer1" "c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" 2.0)
+     ]}])
+
+  (expect "Buy succeeds"
+    "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"
+    (continue-pact 1 false "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"))
+
+  (expect
+    "Expect k:buyer balance to be correct"
+    1.9 (coin.get-balance "k:buyer"))
+
+  (expect
+    "Expect creator balance to be correct"
+    2.1 (coin.get-balance "k:creator"))
+
+  (env-data {
+    "seller-guard": {"keys": ["creator"], "pred": "keys-all"}
+   ,"buyer-guard": {"keys": ["buyer1"], "pred": "keys-all"}})
+
+(expect "buy events"
+  [{"name": "coin.TRANSFER","params": ["k:buyer1" "c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" 2.0]}
+   {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 0.1 "k:creator"]}
+   {"name": "coin.TRANSFER","params": ["c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" "k:creator" 0.1]}
+   {"name": "coin.TRANSFER","params": ["c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" "k:buyer" 1.9]}
+   {"name": "marmalade-v2.ledger.BUY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" "k:buyer1" 1.0 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"]}
+   {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer1" (read-keyset 'buyer-guard)]}
+   {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI" "k:buyer1" 1.0]}
+   {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI","current": 0.0,"previous": 1.0} {"account": "k:buyer1","current": 1.0,"previous": 0.0}]}]
+ (map (remove "module-hash")  (env-events true))
+ )
+
+(rollback-tx)
+
+(begin-tx "Fund creator fungible account")
+
+  (env-data {
+   "creator-guard": {"keys": ["creator"], "pred": "keys-all"}
+   })
+
+  (test-capability (coin.COINBASE))
+  (coin.coinbase "k:creator" (read-keyset 'creator-guard) 2.0)
+
+  (expect "coinbase events"
+   [{"name": "coin.TRANSFER","params": ["" "k:creator" 2.0]}]
+   (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "creator re-buys the token from buyer")
+  (env-hash (hash "offer-royalty-1-buy-creator"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "buyer": "k:creator"
+   ,"buyer_fungible_account": "k:creator"
+   ,"buyer-guard": {"keys": ["creator"], "pred": "keys-all"}
+   })
+
+  (env-sigs
+   [{'key:'creator
+    ,'caps: [
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) "k:buyer" "k:creator"  1.0 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU")
+      (coin.TRANSFER "k:creator" "c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" 2.0)
+     ]}])
+
+  (expect "Buy succeeds"
+    "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"
+    (continue-pact 1 false "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"))
+
+  (expect
+    "Expect k:buyer balance to be correct"
+    1.9 (coin.get-balance "k:buyer"))
+
+  (expect
+    "Expect creator balance to be correct"
+    2.1 (coin.get-balance "k:creator"))
+
+  (env-data {
+    "seller-guard": {"keys": ["creator"], "pred": "keys-all"}
+   ,"buyer-guard": {"keys": ["creator"], "pred": "keys-all"}})
+
+(expect "buy events"
+  [{"name": "coin.TRANSFER","params": ["k:creator" "c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" 2.0]}
+   {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU" "t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 0.1 "k:creator"]}
+   {"name": "coin.TRANSFER","params": ["c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" "k:creator" 0.1]}
+   {"name": "coin.TRANSFER","params": ["c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" "k:buyer" 1.9]}
+   {"name": "marmalade-v2.ledger.BUY","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "k:buyer" "k:creator" 1.0 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"]}
+   {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI" "k:creator" 1.0]}
+   {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:xagtuzvBhb2cixbyeLMFuhRCbs8QWkyX28L71FlXhoA" 1.0 {"account": "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI","current": 0.0,"previous": 1.0} {"account": "k:creator","current": 1.0,"previous": 0.0}]}]
+ (map (remove "module-hash")  (env-events true))
+ )
+
+(rollback-tx)


### PR DESCRIPTION
Managed cap `fungible::TRANSFER` cannot be installed twice, causing failure if the sale was made by the original creator using royalty-policy. Instead, the full sale-price can be installed to allow multiple `fungible::transfer` transactions to succeed from different contracts, still limiting the sum of the price to not exceed the sale-price. The token creator will need to carefully review the fungible payouts so that the policies don't conflict with each other. 