### PR TITLE
Sale interface v2

### DIFF
--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -660,12 +660,16 @@
 (namespace (read-string 'ns))
 
 (module sale-example-v1 GOV
-  (implements marmalade-v2.sale-v1)
+  (implements marmalade-v2.sale-v2)
 
   (defcap GOV () true)
 
   (defun enforce-quote-update:bool (sale-id:string price:decimal)
     (require-capability (marmalade-v2.policy-manager.SALE-GUARD-CALL sale-id price))
+  )
+
+  (defun enforce-withdrawal:bool (sale-id:string)
+    true
   )
 )
 

--- a/pact/policy-manager/sale.interface.pact
+++ b/pact/policy-manager/sale.interface.pact
@@ -1,10 +1,14 @@
 (namespace (read-msg 'ns))
 
-(interface sale-v1
+(interface sale-v2
 
-  " Standard for marmalade-v2 sale contracts to be implemented in quoted sales." 
+  " Standard for marmalade-v2 sale contracts to be implemented in quoted sales."
 
   (defun enforce-quote-update:bool (sale-id:string price:decimal)
     @doc "Read-only Function that is enforced to update quote price at enforce-buy"
+  )
+
+  (defun enforce-withdrawal:bool (sale-id:string)
+    @doc "Read-only Function that is enforced to allow withdrawal from sale"
   )
 )

--- a/pact/sale-contracts/conventional-auction/conventional-auction.pact
+++ b/pact/sale-contracts/conventional-auction/conventional-auction.pact
@@ -204,6 +204,7 @@
       (enforce (< (curr-time) end-date) "Auction has ended")
       (enforce (> bid prev-highest-bid) "Bid is not higher than previous highest bid")
       (enforce (> bid reserve-price) "Bid is not higher than reserve price")
+      (enforce (validate-principal bidder-guard bidder) "Incorrect account guard, only principal accounts allowed")
       (let ((bid-id:string (create-bid-id sale-id bidder)))
         (with-capability (PLACE_BID bidder-guard)
           ; Return amount to previous bidder if there was one

--- a/pact/sale-contracts/conventional-auction/conventional-auction.pact
+++ b/pact/sale-contracts/conventional-auction/conventional-auction.pact
@@ -10,7 +10,7 @@
 
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.policy-manager [BUYER-FUNGIBLE-ACCOUNT-MSG-KEY])
-  (implements marmalade-v2.sale-v1)
+  (implements marmalade-v2.sale-v2)
 
   (defschema auctions-schema
     token-id:string
@@ -99,6 +99,17 @@
         (enforce (= (read-msg "buyer") bidder) "Buyer does not match highest bidder")
         (enforce (= (read-msg "buyer-guard" ) bidder-guard) "Buyer-guard does not match highest bidder-guard")
       )
+    )
+    true
+  )
+
+  (defun enforce-withdrawal:bool (sale-id:string)
+    (with-read auctions sale-id
+      { 'end-date:= end-date,
+        'highest-bid:= highest-bid
+      }
+      (enforce (> (curr-time) end-date) "Auction is still ongoing or hasn't started yet")
+      (enforce (= highest-bid 0.0) "Bid has been placed, can't withdraw")
     )
     true
   )

--- a/pact/sale-contracts/conventional-auction/conventional-auction.repl
+++ b/pact/sale-contracts/conventional-auction/conventional-auction.repl
@@ -36,7 +36,7 @@
 
   (test-capability (coin.COINBASE))
   (coin.coinbase "k:creator" (read-keyset 'creator-guard) 250.0)
-  (coin.coinbase "buyer" (read-keyset 'buyer-guard) 250.0)
+  (coin.coinbase "k:buyer" (read-keyset 'buyer-guard) 250.0)
   (coin.coinbase "k:next-buyer" (read-keyset 'next-buyer-guard) 250.0)
 
   (expect "Create the token"
@@ -246,11 +246,11 @@
 
   (expect-failure "Bid on non-existent auction fails"
     "row not found"
-    (place-bid "bogus-sale-id" "buyer" (read-keyset 'buyer-guard) 100.0)
+    (place-bid "bogus-sale-id" "k:buyer" (read-keyset 'buyer-guard) 100.0)
   )
   (expect-failure "Bid while auction is still closed"
     "Auction has not started yet"
-    (place-bid (read-string "sale-id") "buyer" (read-keyset 'buyer-guard) 100.0)
+    (place-bid (read-string "sale-id") "k:buyer" (read-keyset 'buyer-guard) 100.0)
   )
 (rollback-tx)
 
@@ -269,28 +269,34 @@
   })
   (expect-failure "Bid below reserve price"
     "Bid is not higher than reserve price"
-    (place-bid (read-string "sale-id") "buyer" (read-keyset 'buyer-guard) 40.0)
+    (place-bid (read-string "sale-id") "k:buyer" (read-keyset 'buyer-guard) 40.0)
   )
+
+  (expect-failure "Bid using a named account"
+    "Incorrect account guard, only principal accounts allowed"
+    (place-bid (read-string "sale-id") "buyer" (read-keyset 'buyer-guard) 100.0)
+  )
+
   (env-sigs [
     { 'key: 'buyer
      ,'caps: [
       (PLACE_BID (read-keyset 'buyer-guard)),
-      (coin.TRANSFER "buyer" "u:util.guards1.enforce-guard-any:8iBtcNCfjArejHvxJ0rde1DsWxuhHqOzd1w40jsDPV4" 75.0)
+      (coin.TRANSFER "k:buyer" "u:util.guards1.enforce-guard-any:8iBtcNCfjArejHvxJ0rde1DsWxuhHqOzd1w40jsDPV4" 75.0)
     ]}])
   (expect "Place bid succeeds"
     true
-    (place-bid (read-string "sale-id") "buyer" (read-keyset 'buyer-guard) 75.0)
+    (place-bid (read-string "sale-id") "k:buyer" (read-keyset 'buyer-guard) 75.0)
   )
   (expect "Buyer balance has been deducted"
     175.0
-    (coin.get-balance "buyer")
+    (coin.get-balance "k:buyer")
   )
   (expect "The highest bid has been noted in the auction"
     { "token-id": (read-string "token1-id")
       ,"start-date": 1696204800
       ,"end-date": 1696723200
       ,"highest-bid": 75.0
-      ,"highest-bid-id": (create-bid-id (read-msg "sale-id") "buyer")
+      ,"highest-bid-id": (create-bid-id (read-msg "sale-id") "k:buyer")
       ,"reserve-price": 50.0
     }
     (retrieve-auction (read-string "sale-id"))
@@ -328,7 +334,7 @@
 
   (expect "Previous bidder has received his bid amount back"
     250.0
-    (coin.get-balance "buyer")
+    (coin.get-balance "k:buyer")
   )
   (expect "Next bidder's balance has been deducted"
     125.0

--- a/pact/sale-contracts/conventional-auction/conventional-auction.repl
+++ b/pact/sale-contracts/conventional-auction/conventional-auction.repl
@@ -192,6 +192,45 @@
   )
 (rollback-tx)
 
+(begin-tx "Withdrawal before auction start")
+  (env-hash (hash "bid-withdrawal-before-start"))
+  (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+  (use marmalade-v2.ledger)
+
+  (env-data {
+    "sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+
+  (expect-failure "withdrawing before the auction has ended fails"
+    "Auction is still ongoing or hasn't started yet"
+    (continue-pact 0 true (read-msg 'sale-id))
+  )
+(rollback-tx)
+
+(begin-tx "Withdrawal after auction end")
+  (env-hash (hash "bid-withdrawal-after-end"))
+  (env-chain-data {"block-time": (time "2023-10-10T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+
+  (env-sigs [
+    { 'key: 'creator
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-msg 'token1-id) "k:creator" 1.0 0 (read-msg 'sale-id))]
+     }
+  ])
+
+  (expect "withdrawing after the auction has ended withoud bids succeed"
+    "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+    (continue-pact 0 true (read-msg 'sale-id))
+  )
+(rollback-tx)
+
 (begin-tx "Conventional auction bidding validations")
   (env-hash (hash "bid-conventional-auction-validation"))
   (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
@@ -342,6 +381,21 @@
   (expect-failure "Try to claim the token with the wrong price"
     "Price does not match highest bid"
     (continue-pact 1 false "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")
+  )
+(rollback-tx)
+
+(begin-tx "Withdrawal when bids are placed")
+  (env-hash (hash "bid-withdrawal-bids-placed"))
+  (env-chain-data {"block-time": (time "2023-10-09T00:00:00Z")})
+  (use marmalade-v2.ledger)
+
+  (env-data {
+    "sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+
+  (expect-failure "withdrawing after the auction has ended fails when there are bids placed"
+    "Bid has been placed, can't withdraw"
+    (continue-pact 0 true (read-msg 'sale-id))
   )
 (rollback-tx)
 


### PR DESCRIPTION
Updating the sale interface to v2 to add a hook that controls withdrawals. This gives sale-contracts the option to prevent withdrawals in cases where this is prohibited, for example for running auctions or tokens that have already received a bid.