### PR TITLE
Storing operator-account in collection-policy

### DIFF
--- a/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -21,6 +21,7 @@
     size:integer
     max-size:integer
     operator-guard:guard
+    operator-account:string
   )
 
   (defschema token
@@ -66,6 +67,7 @@
           ,"max-size": collection-size
           ,"size": 0
           ,"operator-guard": operator-guard
+          ,"operator-account": operator-account
           })
           true
       ))

--- a/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -137,6 +137,7 @@
       ,"size": 1
       ,"max-size": 10
       ,"operator-guard": (read-keyset 'operator )
+      ,"operator-account": "k:operator"
     }
     (marmalade-v2.collection-policy-v1.get-collection (read-msg 'collection_id)))
 


### PR DESCRIPTION
Also store the operator-account in the schema next to including it in the `COLLECTION` event which was implemented in #165 