### PR TITLE
Fixes concrete policy field check 

### DIFF
--- a/pact/policy-manager/policy-manager.pact
+++ b/pact/policy-manager/policy-manager.pact
@@ -173,7 +173,7 @@
     [NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY] )
 
   (defun write-concrete-policy:bool (policy-field:string policy:module{kip.token-policy-v2})
-    (contains policy-field CONCRETE_POLICY_LIST)
+    (enforce (contains policy-field CONCRETE_POLICY_LIST) "Not registered as concrete policy")
     (with-capability (CONCRETE-POLICY policy-field policy)
       (write concrete-policies policy-field {
         "policy": policy
@@ -474,7 +474,6 @@
     @doc "Get Quote information"
     (read quotes sale-id)
   )
-
 
   ;; Validate functions
   (defun validate-fungible-account (fungible:module{fungible-v2} account:object{fungible-account})

--- a/pact/policy-manager/policy-manager.repl
+++ b/pact/policy-manager/policy-manager.repl
@@ -100,6 +100,10 @@
   (use marmalade-v2.policy-manager)
   (use marmalade-v2.policy-manager [NON_FUNGIBLE_POLICY])
 
+  (expect-failure "write-concrete-policy fails if concrete policy field is not registered"
+    "Not registered as concrete policy"
+    (write-concrete-policy "not-registered-policy" marmalade-v2.non-fungible-policy-v1))
+
   (expect "upgrade non-fungible-policy"
     true
     (write-concrete-policy NON_FUNGIBLE_POLICY marmalade-v2.non-fungible-policy-v1))


### PR DESCRIPTION
Adds the missing `enforce` check in`policy-manager.write-concrete-policy` function when checkin if concrete policy is one of the registered policies. 