### PR TITLE
Refine transfer-crosschain prohibition

### DIFF
--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -479,7 +479,8 @@
       receiver-guard:guard
       target-chain:string
       amount:decimal )
-    (step (format "{}" [(enforce false "cross chain not supported")]) false)
+    (step
+      (enforce false "cross chain not supported"))
   )
 
   ;;

--- a/pact/ledger/ledger.repl
+++ b/pact/ledger/ledger.repl
@@ -285,5 +285,12 @@
 
 (rollback-tx)
 
-(begin-tx "test utility functions")
+(begin-tx "transfer-crosschain fails")
+  (use mini-guard-utils)
+
+  (expect-failure "transfer-crosschain is prohibited"
+    "cross chain not supported"
+    (marmalade-v2.ledger.transfer-crosschain "" "" "" ALWAYS-TRUE "" 0.0)
+  )
+
 (commit-tx)


### PR DESCRIPTION
Removed unnecessary`format` function in `transfer-crosschain`