### PR TITLE
Remove sale-id from ledger.buy

### DIFF
--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -573,7 +573,7 @@
             (policy-manager.enforce-buy (get-token-info id) seller buyer buyer-guard amount (pact-id))
           )
           (with-capability (BUY id seller buyer amount (pact-id))
-            (buy id seller buyer buyer-guard amount (pact-id))
+            (buy id seller buyer buyer-guard amount)
           )
           (pact-id)
     ))

--- a/pact/ledger/ledger.pact
+++ b/pact/ledger/ledger.pact
@@ -627,7 +627,6 @@
       buyer:string
       buyer-guard:guard
       amount:decimal
-      sale-id:string
     )
     @doc "Complete sale with transfer."
     @model


### PR DESCRIPTION
Unused parameter, `sale-id` is removed from `ledger.buy` 