### PR TITLE
feat: add ability to change guards (guard-policy-v1)

### DIFF
--- a/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -35,6 +35,12 @@
     true
   )
 
+  (defcap GUARD-UPDATED:bool (token-id:string guard-name:string guard:guard)
+    @doc "Emits event for discovery of updating guards"
+    @event
+    true
+  )
+
   (defcap MINT (token-id:string account:string amount:decimal)
     (enforce-guard (get-mint-guard token-id))
   )
@@ -94,6 +100,42 @@
 
   (defun get-guards:object{guards} (token:object{token-info})
     (read policy-guards (at 'id token))
+  )
+
+  (defun update-mint-guard:bool (token-id:string guard:guard)
+    (enforce-guard (get-mint-guard token-id))
+    (update policy-guards token-id {
+      "mint-guard": guard
+    })
+    (emit-event (GUARD-UPDATED token-id "mint-guard" guard))
+    true
+  )
+
+  (defun update-burn-guard:bool (token-id:string guard:guard)
+    (enforce-guard (get-burn-guard token-id))
+    (update policy-guards token-id {
+      "burn-guard": guard
+    })
+    (emit-event (GUARD-UPDATED token-id "burn-guard" guard))
+    true
+  )
+
+  (defun update-sale-guard:bool (token-id:string guard:guard)
+    (enforce-guard (get-sale-guard token-id))
+    (update policy-guards token-id {
+      "sale-guard": guard
+    })
+    (emit-event (GUARD-UPDATED token-id "sale-guard" guard))
+    true
+  )
+
+  (defun update-transfer-guard:bool (token-id:string guard:guard)
+    (enforce-guard (get-transfer-guard token-id))
+    (update policy-guards token-id {
+      "transfer-guard": guard
+    })
+    (emit-event (GUARD-UPDATED token-id "transfer-guard" guard))
+    true
   )
 
   (defun enforce-init:bool

--- a/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -82,3 +82,131 @@
       {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 1.0]}]
     (map (remove "module-hash")  (env-events true)))
 (rollback-tx)
+
+
+(begin-tx "Update guards after creating a token")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.guard-policy-v1)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"mint_guard": {"keys": ["mint"], "pred": "keys-all"}
+    ,"burn_guard": {"keys": ["burn"], "pred": "keys-all"}
+    ,"sale_guard": {"keys": ["sale"], "pred": "keys-all"}
+    ,"transfer_guard": {"keys": ["transfer"], "pred": "keys-all"}
+    ,"updated_guard": {"keys": ["updated"], "pred": "keys-all"}
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect "create token succeeds with mint-guard"
+   true
+   (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ALWAYS-TRUE))
+
+  (env-sigs [
+    { 'key: 'wrong-key
+      ,"caps": []
+    }
+  ])
+
+  (expect-failure "update token mint guard fails without the right mint-guard"
+   "Failure: Tx Failed: Keyset failure (keys-all):"
+   (update-mint-guard (read-msg 'token-id) (read-keyset 'updated_guard)))
+
+  (env-sigs [
+    { 'key: 'mint
+      ,"caps": []
+    }
+  ])
+
+  (expect "update token mint guard succeeds"
+   true
+   (update-mint-guard (read-msg 'token-id) (read-keyset 'updated_guard)))
+
+   (env-sigs [
+    { 'key: 'wrong-key
+      ,"caps": []
+    }
+  ])
+
+  (expect-failure "update token mint guard fails without the right burn-guard"
+   "Failure: Tx Failed: Keyset failure (keys-all):"
+   (update-burn-guard (read-msg 'token-id) (read-keyset 'updated_guard)))
+
+  (env-sigs [
+    { 'key: 'burn
+      ,"caps": []
+    }
+  ])
+
+  (expect "update token burn guard succeeds"
+   true
+   (update-burn-guard (read-msg 'token-id) (read-keyset 'updated_guard)))
+
+
+   (env-sigs [
+    { 'key: 'wrong-key
+      ,"caps": []
+    }
+  ])
+
+  (expect-failure "update token mint guard fails without the right sale-guard"
+   "Failure: Tx Failed: Keyset failure (keys-all):"
+   (update-sale-guard (read-msg 'token-id) (read-keyset 'updated_guard)))
+
+  (env-sigs [
+    { 'key: 'sale
+      ,"caps": []
+    }
+  ])
+
+  (expect "update token sale guard succeeds"
+   true
+   (update-sale-guard (read-msg 'token-id) (read-keyset 'updated_guard)))
+
+
+   (env-sigs [
+    { 'key: 'wrong-key
+      ,"caps": []
+    }
+  ])
+
+  (expect-failure "update token mint guard fails without the right transfer-guard"
+   "Failure: Tx Failed: Keyset failure (keys-all):"
+   (update-transfer-guard (read-msg 'token-id) (read-keyset 'updated_guard)))
+
+  (env-sigs [
+    { 'key: 'transfer
+      ,"caps": []
+    }
+  ])
+
+  (expect "update token transfer guard succeeds"
+   true
+   (update-transfer-guard (read-msg 'token-id) (read-keyset 'updated_guard)))
+
+  (env-sigs [
+    { 'key: 'updated
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-string 'account) 1.0)
+              (marmalade-v2.guard-policy-v1.MINT (read-msg 'token-id) (read-string 'account) 1.0)
+     ]
+    }])
+
+  (expect "Mint token succeeds with updated guard"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (expect "create-token, mint events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" {"burn-guard": (read-keyset 'burn_guard),"mint-guard": (read-keyset 'mint_guard),"sale-guard": (read-keyset 'sale_guard),"transfer-guard": (read-keyset 'transfer_guard)}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "test-default-guard" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARD-UPDATED","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" "mint-guard" (read-keyset 'updated_guard)]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARD-UPDATED","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" "burn-guard" (read-keyset 'updated_guard)]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARD-UPDATED","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" "sale-guard" (read-keyset 'updated_guard)]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARD-UPDATED","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" "transfer-guard" (read-keyset 'updated_guard)]}
+      {"name": "marmalade-v2.ledger.MINT","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" (read-string 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" (read-string 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string 'account),"current": 1.0,"previous": 0.0}]}
+      {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:8t5Og734kszsvMwMgNHB3-KOU1NDAUlPbUUQnl66aWA" 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+(rollback-tx)


### PR DESCRIPTION
The idea of this PR is to add the ability to update the guards.
The only one that can update the guard is the one that has the guard already.

Edge case:
- if the guard is empty, than anyone can update the guard and lock you out of your token