### PR TITLE
Private token policy

### DIFF
--- a/.github/actions/repl/action.yml
+++ b/.github/actions/repl/action.yml
@@ -15,4 +15,4 @@ runs:
         bin/pact -t ${{ inputs.target }} > out.log 2>&1
         cat out.log
         r=`tail -1 out.log | grep "Load successful"`
-        if [ -n "$r" ]; then exit 0; else echo "Pact run failed."; exit 1; fi
+        if [ -n "$r" ]; then exit 0; else cat out.log; echo "Pact run failed."; exit 1; fi

--- a/.github/workflows/test-example-policies.yml
+++ b/.github/workflows/test-example-policies.yml
@@ -38,11 +38,6 @@ jobs:
         with:
           target: examples/policies/timed-mint-policy/timed-mint-policy-v1.repl
 
-      - name: Test soul-bound-policy-v1
-        uses: ./.github/actions/repl
-        with:
-          target: examples/policies/soul-bound-policy/soul-bound-policy-v1.repl
-
       - name: Test private-token-policy-v1
         uses: ./.github/actions/repl
         with:

--- a/.github/workflows/test-example-policies.yml
+++ b/.github/workflows/test-example-policies.yml
@@ -37,3 +37,13 @@ jobs:
         uses: ./.github/actions/repl
         with:
           target: examples/policies/timed-mint-policy/timed-mint-policy-v1.repl
+
+      - name: Test soul-bound-policy-v1
+        uses: ./.github/actions/repl
+        with:
+          target: examples/policies/soul-bound-policy/soul-bound-policy-v1.repl
+
+      - name: Test private-token-policy-v1
+        uses: ./.github/actions/repl
+        with:
+          target: examples/policies/private-token-policy/private-token-policy-v1.repl

--- a/examples/policies/private-token-policy/private-token-policy-v1.pact
+++ b/examples/policies/private-token-policy/private-token-policy-v1.pact
@@ -1,0 +1,107 @@
+(namespace (read-msg 'ns))
+
+(module private-token-policy-v1 GOVERNANCE
+
+  (defconst ADMIN-KS:string "marmalade-examples.private-token-policy")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (implements kip.token-policy-v2)
+  (implements kip.updatable-uri-policy-v1)
+  (use kip.token-policy-v2 [token-info])
+  (use marmalade-v2.guard-policy-v1 [URI-GUARD-MSG-KEY])
+
+  (defcap TOKEN_REVEALED (token-id:string uri:string)
+    @doc "Emitted when the token URI has been revealed"
+    @event
+    true
+  )
+
+  (defun has-guard-policy:bool (policies)
+    (> (length (filter (lambda (policy) (= policy marmalade-v2.guard-policy-v1)) policies)) 0))
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+
+    (enforce (has-guard-policy (at 'policies token)) "Guard policy is required for private tokens")
+
+    (read-msg URI-GUARD-MSG-KEY)
+
+    true
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    true
+  )
+
+  (defun enforce-update-uri:bool
+    ( token:object{kip.token-policy-v2.token-info}
+      new-uri:string
+    )
+    (let* (
+      (token-id:string (at 'id token))
+      (token-info:object{kip.token-policy-v2.token-info} (marmalade-v2.ledger.get-token-info token-id))
+      (token-uri-hash:string (at 'uri token-info))
+    )
+      (enforce (not (= new-uri "")) "URI cannot be empty")
+
+      (enforce (= token-uri-hash (hash new-uri)) "URI does not match the hash")
+
+      (emit-event (TOKEN_REVEALED token-id new-uri))
+     
+      true
+    )
+  )
+)

--- a/examples/policies/private-token-policy/private-token-policy-v1.repl
+++ b/examples/policies/private-token-policy/private-token-policy-v1.repl
@@ -1,0 +1,111 @@
+;;load policy manager, ledger
+(load "../../../pact/marmalade.repl")
+
+(begin-tx "load policy")
+  (env-data {
+    "ns": "marmalade-examples"
+  , "private-token-policy": ["private-token-policy"]
+  , "upgrade": false}
+  )
+  (env-sigs [
+    { 'key: 'private-token-policy
+     ,'caps: []
+  }])
+
+  (ns.write-registry (read-msg 'ns) (read-keyset 'private-token-policy) true)
+  (define-namespace
+    (read-msg 'ns)
+    (read-keyset 'private-token-policy) (read-keyset 'private-token-policy)
+  )
+
+  (namespace (read-msg 'ns))
+
+  (define-keyset (+ (read-msg 'ns) ".private-token-policy") (read-keyset 'private-token-policy))
+  
+  (load "private-token-policy-v1.pact")
+  (typecheck "marmalade-examples.private-token-policy-v1")
+
+(commit-tx)
+
+(begin-tx "Require guard-policy")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.private-token-policy-v1)
+    (use mini-guard-utils)
+  
+  (env-data {
+    "token-id": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"token-id-without-guard-policy": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1] } ALWAYS-TRUE)
+  })
+
+  (expect-failure "Failed to create a token without guard-policy"
+    "Guard policy is required for private tokens"
+    (create-token (read-msg 'token-id-without-guard-policy) 0 (hash "ipfs://secret-uri") [marmalade-examples.private-token-policy-v1] ALWAYS-TRUE))
+
+  (expect-failure "Failed to create a token without uri-guard"
+    "Failure: Tx Failed: No such key in message: uri_guard"
+    (create-token (read-msg 'token-id) 0 (hash "ipfs://secret-uri") [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+(commit-tx)
+
+(begin-tx "Create private token")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.private-token-policy-v1)
+    (use marmalade-v2.guard-policy-v1 [GUARD_SUCCESS])
+    (use mini-guard-utils)
+    
+  (env-data {
+     "token-id": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+     ,"uri_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect "Token created successfully"
+    true
+    (create-token (read-msg 'token-id) 0 (hash "ipfs://secret-uri") [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+  (expect "create-token events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS,"uri-guard":(read-keyset 'uri_guard)}] },
+      {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] (hash "ipfs://secret-uri") ALWAYS-TRUE]}]
+    (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "Reveal private token URI")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.private-token-policy-v1)
+    (use mini-guard-utils)
+
+  (env-data {
+    "secret-uri": "ipfs://secret-uri"
+    ,"token-id": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"uri-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+  
+  (expect-failure "fail if new URI is empty string"
+    "URI cannot be empty"
+    (update-uri (read-msg 'token-id) ""))
+  
+  (expect-failure "fail if new URI is wrong"
+    "URI does not match the hash"
+    (update-uri (read-msg 'token-id) "ipfs://wrong-uri"))
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+      ,'caps: [
+        (marmalade-v2.ledger.UPDATE-URI (read-msg 'token-id) (read-msg 'secret-uri))
+        ,(marmalade-v2.guard-policy-v1.UPDATE-URI (read-msg 'token-id) (read-msg 'secret-uri))]
+    }])
+  
+  (expect "successfully reveal the URI"
+    true
+    (update-uri (read-msg 'token-id) (read-msg 'secret-uri)))
+
+  (expect "update uri events"
+    [{"name": "marmalade-examples.private-token-policy-v1.TOKEN_REVEALED","params": [(read-msg 'token-id) (read-msg 'secret-uri)]} 
+    ,{"name": "marmalade-v2.ledger.UPDATE-URI","params": [(read-msg 'token-id) (read-msg 'secret-uri)]}]
+    (map (remove "module-hash")  (env-events true)))
+    
+  (expect-failure "cannot update the URI after revealing"
+    "URI does not match the hash"
+    (update-uri (read-msg 'token-id) "ipfs://something-new"))
+      
+(commit-tx)

--- a/examples/policies/private-token-policy/private-token-policy-v1.repl
+++ b/examples/policies/private-token-policy/private-token-policy-v1.repl
@@ -79,14 +79,19 @@
     ,"token-id": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
     ,"uri-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
   })
+
+  (expect "token has not been revealed"
+    false
+    (is-revealed (read-msg 'token-id))
+  )
   
   (expect-failure "fail if new URI is empty string"
     "URI cannot be empty"
-    (update-uri (read-msg 'token-id) ""))
+    (reveal-uri (read-msg 'token-id) ""))
   
   (expect-failure "fail if new URI is wrong"
     "URI does not match the hash"
-    (update-uri (read-msg 'token-id) "ipfs://wrong-uri"))
+    (reveal-uri (read-msg 'token-id) "ipfs://wrong-uri"))
 
   (env-sigs [
     { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
@@ -97,15 +102,20 @@
   
   (expect "successfully reveal the URI"
     true
-    (update-uri (read-msg 'token-id) (read-msg 'secret-uri)))
+    (reveal-uri (read-msg 'token-id) (read-msg 'secret-uri)))
 
-  (expect "update uri events"
-    [{"name": "marmalade-examples.private-token-policy-v1.TOKEN_REVEALED","params": [(read-msg 'token-id) (read-msg 'secret-uri)]} 
-    ,{"name": "marmalade-v2.ledger.UPDATE-URI","params": [(read-msg 'token-id) (read-msg 'secret-uri)]}]
+  (expect "reveal uri events"
+    [{"name": "marmalade-v2.ledger.UPDATE-URI","params": [(read-msg 'token-id) (read-msg 'secret-uri)]}
+    ,{"name": "marmalade-examples.private-token-policy-v1.TOKEN_REVEALED","params": [(read-msg 'token-id) (read-msg 'secret-uri)]} ]
     (map (remove "module-hash")  (env-events true)))
+  
+  (expect "token has been revealed"
+    true
+    (is-revealed (read-msg 'token-id))
+  )
     
-  (expect-failure "cannot update the URI after revealing"
-    "URI does not match the hash"
-    (update-uri (read-msg 'token-id) "ipfs://something-new"))
+  (expect-failure "cannot reveal the URI again"
+    "Token URI already revealed"
+    (reveal-uri (read-msg 'token-id) "ipfs://something-new"))
       
 (commit-tx)

--- a/examples/policies/private-token-policy/private-token-policy.md
+++ b/examples/policies/private-token-policy/private-token-policy.md
@@ -1,0 +1,35 @@
+# Private token policy
+
+Private token policy allows creators to make an airdrop without revealing the metadata of the token beforehand. The token URI can be revealed at any time, making the metadata known to all.
+
+## Requirements:
+
+Concrete policy `guard-policy` must be used in conjunction with `private-token-policy` to make sure only an authorized account can update the token URI.
+
+While creating a token, the URI should be the hash of the actual URI. This can be calculated using a local call to the node so there is no trace recorded on the chain.
+
+## Specification, capabilities, events:
+
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrades.
+
+**Events**:
+ - `TOKEN_REVEALED (token-id uri)`: Emitted when the token URI has been revealed.
+
+## Policy Functions
+
+**`enforce-init`:** Enforced during `marmalade-v2.ledger.create-token`, and will ensure the concrete `guard-policy` is present along with the URI guard.
+
+**`enforce-mint`:** Enabled without limitation.
+
+**`enforce-burn`:** Enabled without limitation.
+
+**`enforce-offer`:** Enabled without limitation.
+
+**`enforce-buy`:** Enabled without limitation.
+
+**`enforce-withdraw`:** Enabled without limitation.
+
+**`enforce-transfer`:** Enabled without limitation.
+
+**`enforce-update-uri`:** Enforced during `marmalade-v2.ledger.update-uri`, and it will make sure that the saved hash of the URI matches the hashed new URI.

--- a/examples/policies/private-token-policy/private-token-policy.md
+++ b/examples/policies/private-token-policy/private-token-policy.md
@@ -8,7 +8,13 @@ Concrete policy `guard-policy` must be used in conjunction with `private-token-p
 
 While creating a token, the URI should be the hash of the actual URI. This can be calculated using a local call to the node so there is no trace recorded on the chain.
 
-## Specification, capabilities, events:
+## Specification, tables, capabilities, events:
+
+**Schemas**: `revealed-tokens-schema` is a schema that stores which tokens have been revealed
+  - `revealed`: shows if the URI has been revealed.
+
+**Tables**: `revealed-tokens` table stores which tokens have been revealed.
+  - `id`: the id of the token
 
 **Capabilities**:
  - `GOVERNANCE`: enforces access control of contract upgrades.
@@ -32,4 +38,8 @@ While creating a token, the URI should be the hash of the actual URI. This can b
 
 **`enforce-transfer`:** Enabled without limitation.
 
-**`enforce-update-uri`:** Enforced during `marmalade-v2.ledger.update-uri`, and it will make sure that the saved hash of the URI matches the hashed new URI.
+**`enforce-update-uri`:** Enabled without limitation.
+
+**`reveal-uri`:** Will make sure that the saved hash of the URI matches the hashed new URI and will invoke `marmalade-v2.ledger.update-uri`.
+
+**`is-revealed`:** Check if the URI has been revealed.


### PR DESCRIPTION
# Private token policy

Private token policy allows creators to make an airdrop without revealing the metadata of the token beforehand. The token URI can be revealed at any time, making the metadata known to all.

## Requirements:

Concrete policy `guard-policy` must be used in conjunction with `private-token-policy` to make sure only an authorized account can update the token URI.

While creating a token, the URI should be the hash of the actual URI. This can be calculated using a local call to the node so there is no trace recorded on the chain.

## Specification, capabilities, events:

**Capabilities**:
 - `GOVERNANCE`: enforces access control of contract upgrades.

**Events**:
 - `TOKEN_REVEALED (token-id uri)`: Emitted when the token URI has been revealed.

## Policy Functions

**`enforce-init`:** Enforced during `marmalade-v2.ledger.create-token`, and will ensure the concrete `guard-policy` is present along with the URI guard.

**`enforce-mint`:** Enabled without limitation.

**`enforce-burn`:** Enabled without limitation.

**`enforce-offer`:** Enabled without limitation.

**`enforce-buy`:** Enabled without limitation.

**`enforce-withdraw`:** Enabled without limitation.

**`enforce-transfer`:** Enabled without limitation.

**`enforce-update-uri`:** Enforced during `marmalade-v2.ledger.update-uri`, and it will make sure that the saved hash of the URI matches the hashed new URI.