### PR TITLE
Add bid caps back

### DIFF
--- a/pact/sale-contracts/conventional-auction/conventional-auction.pact
+++ b/pact/sale-contracts/conventional-auction/conventional-auction.pact
@@ -52,6 +52,7 @@
     ( bid-id:string
       sale-id:string
       bid:decimal
+      bidder:string
       token-id:string
     )
     @event
@@ -279,7 +280,7 @@
             )
           )
           (update auctions sale-id { 'highest-bid: bid, 'highest-bid-id: bid-id })
-          (emit-event (BID_PLACED bid-id sale-id bid token-id))
+          (emit-event (BID_PLACED bid-id sale-id bid bidder token-id))
         ))
       true
     )

--- a/pact/sale-contracts/conventional-auction/conventional-auction.pact
+++ b/pact/sale-contracts/conventional-auction/conventional-auction.pact
@@ -51,6 +51,8 @@
   (defcap BID_PLACED:bool
     ( bid-id:string
       sale-id:string
+      bid:decimal
+      token-id:string
     )
     @event
     true
@@ -277,7 +279,7 @@
             )
           )
           (update auctions sale-id { 'highest-bid: bid, 'highest-bid-id: bid-id })
-          (emit-event (BID_PLACED bid-id sale-id))
+          (emit-event (BID_PLACED bid-id sale-id bid token-id))
         ))
       true
     )


### PR DESCRIPTION
I was testing the new graphql endpoint looking to stream live auctions and bid information, then realized the BID_AUCTION capability was changed last update.  Outside of this breaking existing indexer logic that requires performing local calls now, I am unclear what the harm in having this important data readily available?